### PR TITLE
I-#75 cognito domain string catanation

### DIFF
--- a/iac/terraform/aws/cognito/local.tf
+++ b/iac/terraform/aws/cognito/local.tf
@@ -1,5 +1,5 @@
 locals {
-  cognito_domain_name = replace(replace(replace(replace("${var.environment}", "aws", ""), "amazon", ""), "cognito", ""), "-", "")
-  productionEnvironment        = var.environment == module.environments.PRODUCTION ? 1 : 0
-  NonProductionEnvironment     = var.environment == module.environments.PRODUCTION ? 0 : 1
+  cognito_domain_name      = "bloodconnect-${replace(replace(replace(replace(var.environment, "aws", ""), "amazon", ""), "cognito", ""), "-", "")}"
+  productionEnvironment    = var.environment == module.environments.PRODUCTION ? 1 : 0
+  NonProductionEnvironment = var.environment == module.environments.PRODUCTION ? 0 : 1
 }


### PR DESCRIPTION
Fixes #
Cognito domain name should be unique universally. included string "bloodconnect-" in order to make the domain unique.
