### PR TITLE
NO-TICKET: Added old cognito url for now

### DIFF
--- a/iac/terraform/aws/cognito/cognito.tf
+++ b/iac/terraform/aws/cognito/cognito.tf
@@ -126,6 +126,11 @@ resource "aws_cognito_user_pool_domain" "custom_domain" {
   certificate_arn = var.acm_certificate_arn
 }
 
+resource "aws_cognito_user_pool_domain" "cognito_domain" {
+  domain       = local.cognito_old_domain_name
+  user_pool_id = aws_cognito_user_pool.user_pool.id
+}
+
 resource "aws_cognito_user_pool_client" "app_pool_client" {
   name                                 = "${var.environment}-app-pool-client"
   user_pool_id                         = aws_cognito_user_pool.user_pool.id

--- a/iac/terraform/aws/cognito/local.tf
+++ b/iac/terraform/aws/cognito/local.tf
@@ -1,4 +1,5 @@
 locals {
-  cognito_domain_prefix = var.environment == module.environments.PRODUCTION ? "signin" : "signin-${replace(replace(replace(replace(var.environment, "aws", ""), "amazon", ""), "cognito", ""), "-", "")}"
-  cognito_domain_name   = "${local.cognito_domain_prefix}.${var.bloodconnect_domain}"
+  cognito_old_domain_name = "bloodconnect-${replace(replace(replace(replace(var.environment, "aws", ""), "amazon", ""), "cognito", ""), "-", "")}"
+  cognito_domain_prefix   = var.environment == module.environments.PRODUCTION ? "signin" : "signin-${replace(replace(replace(replace(var.environment, "aws", ""), "amazon", ""), "cognito", ""), "-", "")}"
+  cognito_domain_name     = "${local.cognito_domain_prefix}.${var.bloodconnect_domain}"
 }


### PR DESCRIPTION
We change the cognito URL from `*.auth.ap-south-1.amazoncognito.com` URL to `signin*.bloodconnect.net` URL. but the production app using the old one. for now, kept the old one so that there is no issue in the app.

- [x] Does not depend on other PRs
- [ ] Depends on other PR being merged first: #

## What kind of change does this PR introduce (check at least one)

- [ ] Bugfix
- [ ] Improvement
- [ ] New feature
- [ ] Refactor
- [ ] Infrastructure
- [ ] Other (please specify)

## How would you describe the changes in a changelog (1-2 lines)?

Provide a brief overview of the changes introduced in this pull request.

## Related Issues/PRs (optional)

Link to the relevant issue(s) or provide a clear description of the problem or feature being addressed.

## How to test

- [ ] Needs regression testing (add QA needed label)

## Checklist

- [ ] I have tested these changes locally and they function as expected.
- [ ] I have added or updated necessary documentation to reflect the changes.
- [ ] I have followed the project's coding style and guidelines.
- [ ] I have added appropriate test coverage to ensure the changes are functioning correctly.
- [ ] I have checked for any potential conflicts with other branches or pull requests.
- [ ] I have updated necessary OpenAPI specs

## Reviewer Request (optional)

If you have any specific requests or suggestions for reviewers, mention them here.

## Screenshots (optional)

If applicable, provide any additional screenshots or GIFs that showcase the changes made in this pull request.

## Demo Link (optional)

If applicable, provide a link to a live demo or deployment where the changes can be reviewed.

## Known Issues (optional)

If there are any known issues or limitations with the changes made in this pull request, describe them here.

## Additional Notes (optional)

Add any additional notes or comments you think are relevant to this pull request.

## Deploy risk & follow up

Please assess risk & follow up on deployment of this PR. Elaborate your choice if selecting anything other than 'No risk'.

- [x] No risk
- [ ] Low
- [ ] High
