### PR TITLE
NO-TICKET: Added dashboard for monitoring donor search invocations

### DIFF
--- a/iac/terraform/aws/dashboard/dashboard.tf
+++ b/iac/terraform/aws/dashboard/dashboard.tf
@@ -1,0 +1,30 @@
+resource "aws_cloudwatch_dashboard" "dashboard" {
+  dashboard_name = "${var.environment}-dashboard"
+  dashboard_body = jsonencode(
+    {
+      widgets = [
+        {
+          type   = "log"
+          x      = 0
+          y      = 0
+          height = 6
+          width  = 24
+          properties = {
+            query  = <<-EOT
+              SOURCE '/aws/lambda/${var.donor_search_lambda_name}'
+              | fields @timestamp, requestPostId, msg
+              | filter ispresent(requestPostId) and requestPostId != ""
+              | filter msg like /checking targeted execution time/
+              | stats count(*) as count by requestPostId
+              | sort count desc
+              | limit 20
+            EOT
+            region = data.aws_region.current.name
+            title  = "Donor Search Invocation Count by Request ID"
+            view   = "table"
+          }
+        },
+      ]
+    }
+  )
+}

--- a/iac/terraform/aws/dashboard/data.tf
+++ b/iac/terraform/aws/dashboard/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/iac/terraform/aws/dashboard/variables.tf
+++ b/iac/terraform/aws/dashboard/variables.tf
@@ -1,0 +1,9 @@
+variable "environment" {
+  type        = string
+  description = "Deployment environment"
+}
+
+variable "donor_search_lambda_name" {
+  type        = string
+  description = "Donor search lambda name"
+}

--- a/iac/terraform/aws/donor_search/outputs.tf
+++ b/iac/terraform/aws/donor_search/outputs.tf
@@ -5,3 +5,7 @@ output "donation_request_queue_arn" {
 output "donation_status_manager_queue_arn" {
   value = module.donation_status_manager_queue.queue_arn
 }
+
+output "donor_search_lambda_name" {
+  value = module.donor_search_lambda["donor-search"].lambda_function_name
+}

--- a/iac/terraform/aws/modules.tf
+++ b/iac/terraform/aws/modules.tf
@@ -85,3 +85,9 @@ module "logger" {
   source      = "./logger"
   environment = var.environment
 }
+
+module "dashboard" {
+  source                   = "./dashboard"
+  environment              = var.environment
+  donor_search_lambda_name = module.donor_search.donor_search_lambda_name
+}


### PR DESCRIPTION
Added dashboard for monitoring donor search lambda invocation counts

- [x] Does not depend on other PRs
- [ ] Depends on other PR being merged first: #

## What kind of change does this PR introduce (check at least one)

- [ ] Bugfix
- [ ] Improvement
- [x] New feature
- [ ] Refactor
- [ ] Infrastructure
- [ ] Other (please specify)

## How would you describe the changes in a changelog (1-2 lines)?

Provide a brief overview of the changes introduced in this pull request.

## Related Issues/PRs (optional)

Link to the relevant issue(s) or provide a clear description of the problem or feature being addressed.

## How to test

- [ ] Needs regression testing (add QA needed label)

## Checklist

- [x] I have tested these changes locally and they function as expected.
- [ ] I have added or updated necessary documentation to reflect the changes.
- [ ] I have followed the project's coding style and guidelines.
- [ ] I have added appropriate test coverage to ensure the changes are functioning correctly.
- [ ] I have checked for any potential conflicts with other branches or pull requests.
- [ ] I have updated necessary OpenAPI specs

## Reviewer Request (optional)

If you have any specific requests or suggestions for reviewers, mention them here.

## Screenshots (optional)

If applicable, provide any additional screenshots or GIFs that showcase the changes made in this pull request.

## Demo Link (optional)

If applicable, provide a link to a live demo or deployment where the changes can be reviewed.

## Known Issues (optional)

If there are any known issues or limitations with the changes made in this pull request, describe them here.

## Additional Notes (optional)

Add any additional notes or comments you think are relevant to this pull request.

## Deploy risk & follow up

Please assess risk & follow up on deployment of this PR. Elaborate your choice if selecting anything other than 'No risk'.

- [x] No risk
- [ ] Low
- [ ] High
