### PR TITLE
NO-TICKET:  Reduce SQS polling costs by 60% with Lambda concurrency limits

### DIFF
--- a/iac/terraform/aws/notification/sqs_trigger.tf
+++ b/iac/terraform/aws/notification/sqs_trigger.tf
@@ -1,6 +1,10 @@
 resource "aws_lambda_event_source_mapping" "sqs_trigger" {
   event_source_arn = aws_sqs_queue.push_notification_queue.arn
   function_name    = module.lambda["send-push-notification"].lambda_function_name
-  batch_size       = 1
+  batch_size       = 10
   enabled          = true
+
+  scaling_config {
+    maximum_concurrency = 2
+  }
 }

--- a/iac/terraform/aws/sqs/sqs.tf
+++ b/iac/terraform/aws/sqs/sqs.tf
@@ -20,6 +20,10 @@ resource "aws_lambda_event_source_mapping" "this" {
   function_name    = var.lambda_function_arn
   batch_size       = var.batch_size
   enabled          = true
+
+  scaling_config {
+    maximum_concurrency = 2
+  }
 }
 
 resource "aws_sqs_queue_policy" "this" {


### PR DESCRIPTION
## Summary
Optimizes SQS-Lambda event source mappings to reduce idle polling costs:

  - Added `maximum_concurrency = 2` to all SQS Lambda triggers (down from default 5 pollers)
  - Increased `batch_size` from 1 to 10 for push notification queue

## Fixes / Resolves
- update batch size and add scaling configuration for SQS event source mapping

## Type of change

- [ ] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Infra
- [ ] Other: __________

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests or docs
- [ ] Follows code style guidelines

## Dependencies

- [ ] Depends on: #

## Notes (Optional)

Any extra context or reviewer notes.
