### PR TITLE
Adjust SQS visibility timeout and update Lambda event source mapping batch size

### DIFF
--- a/core/services/aws/notification/sendPushNotification.ts
+++ b/core/services/aws/notification/sendPushNotification.ts
@@ -1,4 +1,4 @@
-import type { SQSEvent, SQSRecord } from 'aws-lambda'
+import type { SQSBatchResponse, SQSEvent, SQSRecord } from 'aws-lambda'
 import type {
   NotificationAttributes
 } from '../../../application/notificationWorkflow/Types'
@@ -12,6 +12,7 @@ import NotificationOperationError from '../../../application/notificationWorkflo
 import DonationNotificationDynamoDbOperations from '../commons/ddbOperations/DonationNotificationDynamoDbOperations'
 import UserDynamoDbOperations from '../commons/ddbOperations/UserDynamoDbOperations'
 import { Config } from 'commons/libs/config/config'
+import { GENERIC_CODES } from '../../../../commons/libs/constants/GenericCodes'
 
 const userDeviceToSnsEndpointMap = new LocalCacheMapManager<string, string>(
   MAX_LOCAL_CACHE_SIZE_COUNT
@@ -35,13 +36,34 @@ const userDynamoDbOperations = new UserDynamoDbOperations(
   config.awsRegion
 )
 
-async function sendPushNotification(event: SQSEvent): Promise<void> {
-  for (const record of event.Records) {
-    await processSQSRecord(record)
+const NON_RETRYABLE_CODES = new Set([
+  GENERIC_CODES.BAD_REQUEST,
+  GENERIC_CODES.NOT_FOUND,
+  GENERIC_CODES.UNAUTHORIZED
+])
+
+function isNonRetryable(error: unknown): boolean {
+  if (error instanceof NotificationOperationError) {
+    return NON_RETRYABLE_CODES.has(error.errorCode)
   }
+
+  return false
 }
 
-async function processSQSRecord(record: SQSRecord): Promise<void> {
+async function sendPushNotification(event: SQSEvent): Promise<SQSBatchResponse> {
+  const batchItemFailures: SQSBatchResponse['batchItemFailures'] = []
+
+  for (const record of event.Records) {
+    const failed = await processSQSRecord(record)
+    if (failed) {
+      batchItemFailures.push({ itemIdentifier: record.messageId })
+    }
+  }
+
+  return { batchItemFailures }
+}
+
+async function processSQSRecord(record: SQSRecord): Promise<boolean> {
   const body: NotificationAttributes
     = typeof record.body === 'string' && record.body.trim() !== '' ? JSON.parse(record.body) : {}
 
@@ -58,13 +80,18 @@ async function processSQSRecord(record: SQSRecord): Promise<void> {
       userDeviceToSnsEndpointMap,
       new SNSOperations(config.awsRegion, config.platformArnApns, config.platformArnFcm)
     )
+
+    return false
   } catch (error) {
-    if (error instanceof NotificationOperationError) {
-      serviceLogger.error(error.message)
-    } else {
-      serviceLogger.error(error)
+    if (isNonRetryable(error)) {
+      serviceLogger.error({ error, messageId: record.messageId }, 'non-retryable error, skipping message')
+
+      return false
     }
-    throw error
+
+    serviceLogger.error({ error, messageId: record.messageId }, 'retryable error, marking for retry')
+
+    return true
   }
 }
 

--- a/iac/terraform/aws/notification/queues.tf
+++ b/iac/terraform/aws/notification/queues.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "push_notification_dlq" {
 resource "aws_sqs_queue" "push_notification_queue" {
   #checkov:skip=CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
   name                       = "${var.environment}-push-notification-queue"
-  visibility_timeout_seconds = 60
+  visibility_timeout_seconds = 180
   message_retention_seconds  = 345600 # 4 days
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.push_notification_dlq.arn

--- a/iac/terraform/aws/notification/queues.tf
+++ b/iac/terraform/aws/notification/queues.tf
@@ -7,7 +7,7 @@ resource "aws_sqs_queue" "push_notification_dlq" {
 resource "aws_sqs_queue" "push_notification_queue" {
   #checkov:skip=CKV_AWS_27: "Ensure all data stored in the SQS queue is encrypted"
   name                       = "${var.environment}-push-notification-queue"
-  visibility_timeout_seconds = 180
+  visibility_timeout_seconds = 120
   message_retention_seconds  = 345600 # 4 days
   redrive_policy = jsonencode({
     deadLetterTargetArn = aws_sqs_queue.push_notification_dlq.arn

--- a/iac/terraform/aws/notification/sqs_trigger.tf
+++ b/iac/terraform/aws/notification/sqs_trigger.tf
@@ -1,10 +1,6 @@
 resource "aws_lambda_event_source_mapping" "sqs_trigger" {
   event_source_arn = aws_sqs_queue.push_notification_queue.arn
   function_name    = module.lambda["send-push-notification"].lambda_function_name
-  batch_size       = 10
+  batch_size       = 1
   enabled          = true
-
-  scaling_config {
-    maximum_concurrency = 2
-  }
 }

--- a/iac/terraform/aws/notification/sqs_trigger.tf
+++ b/iac/terraform/aws/notification/sqs_trigger.tf
@@ -1,6 +1,7 @@
 resource "aws_lambda_event_source_mapping" "sqs_trigger" {
-  event_source_arn = aws_sqs_queue.push_notification_queue.arn
-  function_name    = module.lambda["send-push-notification"].lambda_function_name
-  batch_size       = 1
-  enabled          = true
+  event_source_arn        = aws_sqs_queue.push_notification_queue.arn
+  function_name           = module.lambda["send-push-notification"].lambda_function_name
+  batch_size              = 10
+  enabled                 = true
+  function_response_types = ["ReportBatchItemFailures"]
 }


### PR DESCRIPTION
…batch size

## Summary

- Enable partial batch failure reporting (ReportBatchItemFailures) on the SQS → Lambda trigger so only failed messages are retried, not the entire batch
 - Increase SQS visibility timeout from 60s to 120s (Lambda timeout + 60s buffer) to prevent duplicate processing from timeout races
 - Remove the maximum_concurrency = 2 cap to allow Lambda to scale naturally
 - Classify non-retryable errors (400, 401, 404) in the Lambda handler so permanently failing messages are dropped instead of being retried endlessly

## Fixes / Resolves

- Fixes #
- Resolves #

## Type of change

- [x] Bugfix
- [ ] Feature
- [ ] Refactor
- [ ] Docs
- [ ] Infra
- [ ] Other: __________

## Checklist

- [ ] Tested locally
- [ ] Added/updated tests or docs
- [ ] Follows code style guidelines

## Dependencies

- [ ] Depends on: #

## Notes (Optional)

Any extra context or reviewer notes.
