### PR TITLE
In-app Chat (Grimoire)

### DIFF
--- a/clients/mobile/__tests__/chat/ChatInbox.test.tsx
+++ b/clients/mobile/__tests__/chat/ChatInbox.test.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import ChatInbox from '../../src/chat/ChatInbox'
+import { ThemeProvider } from '../../src/setup/theme/context/ThemeContext'
+import { ChatRole } from '../../../../commons/dto/ChatDTO'
+import { SCREENS } from '../../src/setup/constant/screens'
+
+const mockNavigate = jest.fn()
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate })
+}))
+
+const mockMarkRead = jest.fn()
+const mockInboxState = {
+  channels: [
+    { channelId: 'seeker#req#donor', role: ChatRole.SEEKER, lastMessageAt: '2026-06-26T10:00:00.000Z', unread: true },
+    { channelId: 's2#r2#d2', role: ChatRole.DONOR, lastMessageAt: '2026-06-26T09:00:00.000Z', unread: false }
+  ],
+  loading: false,
+  error: null,
+  refresh: jest.fn(),
+  markRead: mockMarkRead
+}
+jest.mock('../../src/chat/useChatInbox', () => ({
+  useChatInbox: () => mockInboxState
+}))
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider>{component}</ThemeProvider>)
+
+describe('ChatInbox', () => {
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('lists channels and shows an unread badge only for unread channels', () => {
+    const { getAllByText, getAllByTestId } = renderWithTheme(<ChatInbox />)
+
+    expect(getAllByText('Chat with donor')).toHaveLength(1)
+    expect(getAllByText('Chat with seeker')).toHaveLength(1)
+    // Only the first channel is unread.
+    expect(getAllByTestId('unread-badge')).toHaveLength(1)
+  })
+
+  it('navigates to the chat room and marks read when an unread channel is opened', () => {
+    const { getByText } = renderWithTheme(<ChatInbox />)
+
+    fireEvent.press(getByText('Chat with donor'))
+
+    expect(mockMarkRead).toHaveBeenCalledWith('seeker#req#donor')
+    expect(mockNavigate).toHaveBeenCalledWith(SCREENS.CHAT_ROOM, { channelId: 'seeker#req#donor' })
+  })
+})

--- a/clients/mobile/__tests__/chat/ChatRoom.test.tsx
+++ b/clients/mobile/__tests__/chat/ChatRoom.test.tsx
@@ -1,0 +1,71 @@
+import React from 'react'
+import { render } from '@testing-library/react-native'
+import ChatRoom from '../../src/chat/ChatRoom'
+import { ThemeProvider } from '../../src/setup/theme/context/ThemeContext'
+import { ChatChannelStatus } from '../../../../commons/dto/ChatDTO'
+
+jest.mock('@react-navigation/native', () => ({
+  useRoute: () => ({ params: { channelId: 'seeker-1#req-1#donor-1' } })
+}))
+
+jest.mock('../../src/userWorkflow/context/UserProfileContext', () => ({
+  useUserProfile: () => ({ userProfile: { userId: 'donor-1' } })
+}))
+
+const chatRoomState: Record<string, unknown> = {}
+jest.mock('../../src/chat/useChatRoom', () => ({
+  useChatRoom: () => chatRoomState
+}))
+
+const context = {
+  requestedBloodGroup: 'O+',
+  urgencyLevel: 'urgent',
+  donationDateTime: '2026-06-30T10:00:00.000Z',
+  location: 'Dhaka Medical'
+}
+
+const messages = [
+  { channelId: 'c', messageId: 'm2', senderId: 'donor-1', content: 'mine', createdAt: '2026-06-26T10:00:02.000Z' },
+  { channelId: 'c', messageId: 'm1', senderId: 'seeker-1', content: 'theirs', createdAt: '2026-06-26T10:00:01.000Z' }
+]
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider>{component}</ThemeProvider>)
+
+describe('ChatRoom', () => {
+  it('renders the header context snapshot on a cold-start deep-link (no post fetch)', () => {
+    Object.assign(chatRoomState, {
+      messages, channel: { status: ChatChannelStatus.OPEN, context }, loading: false, error: null, send: jest.fn()
+    })
+
+    const { getByText } = renderWithTheme(<ChatRoom />)
+
+    expect(getByText('O+')).toBeTruthy()
+    expect(getByText('Dhaka Medical')).toBeTruthy()
+    // Both participants' messages render.
+    expect(getByText('mine')).toBeTruthy()
+    expect(getByText('theirs')).toBeTruthy()
+  })
+
+  it('shows the input when the channel is open', () => {
+    Object.assign(chatRoomState, {
+      messages: [], channel: { status: ChatChannelStatus.OPEN, context }, loading: false, error: null, send: jest.fn()
+    })
+
+    const { getByText, queryByText } = renderWithTheme(<ChatRoom />)
+
+    expect(getByText('Send')).toBeTruthy()
+    expect(queryByText(/conversation is closed/i)).toBeNull()
+  })
+
+  it('shows a read-only locked banner instead of the input when the channel is locked', () => {
+    Object.assign(chatRoomState, {
+      messages: [], channel: { status: ChatChannelStatus.LOCKED, context }, loading: false, error: null, send: jest.fn()
+    })
+
+    const { getByText, queryByText } = renderWithTheme(<ChatRoom />)
+
+    expect(getByText(/conversation is closed/i)).toBeTruthy()
+    expect(queryByText('Send')).toBeNull()
+  })
+})

--- a/clients/mobile/__tests__/chat/ChatWebSocketClient.test.ts
+++ b/clients/mobile/__tests__/chat/ChatWebSocketClient.test.ts
@@ -1,0 +1,114 @@
+import { ChatWebSocketClient } from '../../src/chat/ChatWebSocketClient'
+import type { WebSocketLike } from '../../src/chat/ChatWebSocketClient'
+
+type FakeSocket = WebSocketLike & { sent: string[] }
+
+const createFakeSocket = (): FakeSocket => ({
+  sent: [],
+  send(data: string) { this.sent.push(data) },
+  close: jest.fn(),
+  onopen: null,
+  onmessage: null,
+  onclose: null,
+  onerror: null
+})
+
+const setup = () => {
+  const sockets: FakeSocket[] = []
+  const urls: string[] = []
+  const client = new ChatWebSocketClient({
+    url: 'wss://example/chat',
+    getToken: async() => 'tok en',
+    webSocketFactory: (url: string) => {
+      urls.push(url)
+      const socket = createFakeSocket()
+      sockets.push(socket)
+
+      return socket
+    },
+    baseReconnectDelayMs: 1000,
+    maxReconnectDelayMs: 8000
+  })
+
+  return { client, sockets, urls }
+}
+
+describe('ChatWebSocketClient', () => {
+  beforeEach(() => { jest.useFakeTimers() })
+  afterEach(() => { jest.useRealTimers() })
+
+  it('connects with the auth token on the query string', async() => {
+    const { client, urls } = setup()
+
+    await client.connect()
+
+    expect(urls[0]).toBe('wss://example/chat?token=tok%20en')
+  })
+
+  it('reconnects with exponential backoff after an unexpected close', async() => {
+    const { client, sockets, urls } = setup()
+    await client.connect()
+    expect(urls).toHaveLength(1)
+
+    sockets[0].onclose?.()
+    await jest.advanceTimersByTimeAsync(999)
+    expect(urls).toHaveLength(1)
+    await jest.advanceTimersByTimeAsync(1)
+    expect(urls).toHaveLength(2)
+
+    sockets[1].onclose?.()
+    await jest.advanceTimersByTimeAsync(1999)
+    expect(urls).toHaveLength(2)
+    await jest.advanceTimersByTimeAsync(1)
+    expect(urls).toHaveLength(3)
+  })
+
+  it('resets the backoff to the base delay after a successful open', async() => {
+    const { client, sockets, urls } = setup()
+    await client.connect()
+
+    sockets[0].onclose?.()
+    await jest.advanceTimersByTimeAsync(1000)
+    expect(urls).toHaveLength(2)
+
+    sockets[1].onopen?.()
+    sockets[1].onclose?.()
+    await jest.advanceTimersByTimeAsync(999)
+    expect(urls).toHaveLength(2)
+    await jest.advanceTimersByTimeAsync(1)
+    expect(urls).toHaveLength(3)
+  })
+
+  it('does not reconnect after an explicit close', async() => {
+    const { client, sockets, urls } = setup()
+    await client.connect()
+
+    client.close()
+    expect(sockets[0].close).toHaveBeenCalled()
+
+    await jest.advanceTimersByTimeAsync(10000)
+    expect(urls).toHaveLength(1)
+  })
+
+  it('only sends when open and frames the sendMessage action', async() => {
+    const { client, sockets } = setup()
+    await client.connect()
+
+    expect(client.send({ channelId: 'c', content: 'hi' })).toBe(false)
+
+    sockets[0].onopen?.()
+    expect(client.send({ channelId: 'c', content: 'hi' })).toBe(true)
+    expect(JSON.parse(sockets[0].sent[0])).toEqual({ action: 'sendMessage', channelId: 'c', content: 'hi' })
+  })
+
+  it('delivers parsed messages to subscribers', async() => {
+    const { client, sockets } = setup()
+    const received: unknown[] = []
+    client.onMessage((message) => { received.push(message) })
+
+    await client.connect()
+    sockets[0].onmessage?.({ data: JSON.stringify({ messageId: '1', content: 'yo' }) })
+
+    expect(received).toEqual([{ messageId: '1', content: 'yo' }])
+  })
+})

--- a/clients/mobile/__tests__/chat/chatConfig.test.ts
+++ b/clients/mobile/__tests__/chat/chatConfig.test.ts
@@ -1,0 +1,33 @@
+// Mutable expo-constants mock so each test sets CHAT_ENABLED before the module under test reads it.
+const mockExtra: { CHAT_ENABLED?: string } = {}
+jest.mock('expo-constants', () => ({ __esModule: true, default: { get expoConfig() { return { extra: mockExtra } } } }))
+
+// isChatEnabled is the single gate for both chat routes (routes.ts) and the entry-point buttons
+// (DonorResponses/PostCard), so exercising it here covers the flag-off hides / flag-on shows behaviour
+// without importing the full screen graph that routes.ts pulls in.
+describe('isChatEnabled', () => {
+  afterEach(() => { delete mockExtra.CHAT_ENABLED; jest.resetModules() })
+
+  it('is true only when CHAT_ENABLED is the string "true"', () => {
+    jest.isolateModules(() => {
+      mockExtra.CHAT_ENABLED = 'true'
+
+      expect(require('../../src/chat/chatConfig').isChatEnabled()).toBe(true)
+    })
+  })
+
+  it('is false when CHAT_ENABLED is unset', () => {
+    jest.isolateModules(() => {
+
+      expect(require('../../src/chat/chatConfig').isChatEnabled()).toBe(false)
+    })
+  })
+
+  it('is false for any value other than "true"', () => {
+    jest.isolateModules(() => {
+      mockExtra.CHAT_ENABLED = 'false'
+
+      expect(require('../../src/chat/chatConfig').isChatEnabled()).toBe(false)
+    })
+  })
+})

--- a/clients/mobile/__tests__/chat/chatEntryPoints.test.tsx
+++ b/clients/mobile/__tests__/chat/chatEntryPoints.test.tsx
@@ -1,0 +1,35 @@
+import React from 'react'
+import { render, fireEvent } from '@testing-library/react-native'
+import DonorResponses from '../../src/myActivity/myPosts/donorResponses/DonorResponses'
+import { ThemeProvider } from '../../src/setup/theme/context/ThemeContext'
+
+const donors = [
+  { donorId: 'donor-1', donorName: 'Alice' },
+  { donorId: 'donor-2', donorName: 'Bob' }
+]
+
+const renderWithTheme = (component: React.ReactElement) =>
+  render(<ThemeProvider>{component}</ThemeProvider>)
+
+describe('DonorResponses chat entry point', () => {
+  it('renders a Chat button per donor and fires onChatPress with the donorId when chat is enabled', () => {
+    const onChatPress = jest.fn()
+    const { getAllByText } = renderWithTheme(
+      <DonorResponses acceptedDonors={donors} handlePressDonor={jest.fn()} onChatPress={onChatPress} />
+    )
+
+    const chatButtons = getAllByText('Chat')
+    expect(chatButtons).toHaveLength(2)
+
+    fireEvent.press(chatButtons[0])
+    expect(onChatPress).toHaveBeenCalledWith('donor-1')
+  })
+
+  it('renders no Chat button when chat is disabled (onChatPress undefined)', () => {
+    const { queryByText } = renderWithTheme(
+      <DonorResponses acceptedDonors={donors} handlePressDonor={jest.fn()} />
+    )
+
+    expect(queryByText('Chat')).toBeNull()
+  })
+})

--- a/clients/mobile/__tests__/chat/notificationRouting.test.ts
+++ b/clients/mobile/__tests__/chat/notificationRouting.test.ts
@@ -1,0 +1,17 @@
+import { SCREEN_FOR_NOTIFICATION } from '../../src/setup/notification/NotificationProvider'
+import { SCREENS } from '../../src/setup/constant/screens'
+import { NotificationType } from '../../../../commons/dto/NotificationDTO'
+
+describe('chat notification routing', () => {
+  it('routes a CHAT_MESSAGE notification to the chat room with the channelId', () => {
+    const config = SCREEN_FOR_NOTIFICATION[NotificationType.CHAT_MESSAGE]
+
+    expect(config?.screen).toBe(SCREENS.CHAT_ROOM)
+    expect(config?.getParams?.({
+      channelId: 'seeker#req#donor',
+      senderId: 'seeker',
+      messageId: '01HZ',
+      createdAt: '2026-06-26T10:00:00.000Z'
+    })).toEqual({ channelId: 'seeker#req#donor' })
+  })
+})

--- a/clients/mobile/__tests__/chat/useChatInbox.test.ts
+++ b/clients/mobile/__tests__/chat/useChatInbox.test.ts
@@ -1,0 +1,48 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { useChatInbox } from '../../src/chat/useChatInbox'
+import { fetchChatChannels, markChatRead } from '../../src/chat/chatService'
+import { ChatRole } from '../../../../commons/dto/ChatDTO'
+
+jest.mock('../../src/setup/clients/useFetchClient', () => ({
+  useFetchClient: () => ({})
+}))
+
+jest.mock('../../src/chat/chatService', () => ({
+  fetchChatChannels: jest.fn(),
+  markChatRead: jest.fn()
+}))
+
+const membership = {
+  userId: 'u',
+  channelId: 'seeker#req#donor',
+  role: ChatRole.DONOR,
+  lastMessageAt: '2020-06-26T10:00:00.000Z',
+  lastReadAt: '2020-06-26T09:00:00.000Z',
+  createdAt: '2020-06-26T08:00:00.000Z'
+}
+
+describe('useChatInbox', () => {
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('flags a channel unread when lastMessageAt is newer than lastReadAt', async() => {
+    (fetchChatChannels as jest.Mock).mockResolvedValue({ data: [membership], status: 200 })
+
+    const { result } = renderHook(() => useChatInbox())
+
+    await waitFor(() => { expect(result.current.channels).toHaveLength(1) })
+    expect(result.current.channels[0].unread).toBe(true)
+  })
+
+  it('clears the unread indicator after markRead', async() => {
+    (fetchChatChannels as jest.Mock).mockResolvedValue({ data: [membership], status: 200 })
+    ;(markChatRead as jest.Mock).mockResolvedValue({ success: true, status: 200 })
+
+    const { result } = renderHook(() => useChatInbox())
+    await waitFor(() => { expect(result.current.channels).toHaveLength(1) })
+
+    await act(async() => { await result.current.markRead('seeker#req#donor') })
+
+    expect(markChatRead).toHaveBeenCalledWith('seeker#req#donor', expect.anything())
+    expect(result.current.channels[0].unread).toBe(false)
+  })
+})

--- a/clients/mobile/__tests__/chat/useChatRoom.test.ts
+++ b/clients/mobile/__tests__/chat/useChatRoom.test.ts
@@ -1,0 +1,70 @@
+import { renderHook, act, waitFor } from '@testing-library/react-native'
+import { useChatRoom } from '../../src/chat/useChatRoom'
+import { fetchChatHistory, markChatRead } from '../../src/chat/chatService'
+import { createChatWebSocketClient } from '../../src/chat/chatClientFactory'
+
+jest.mock('../../src/setup/clients/useFetchClient', () => ({
+  useFetchClient: () => ({})
+}))
+
+jest.mock('../../src/chat/chatService', () => ({
+  fetchChatHistory: jest.fn(),
+  markChatRead: jest.fn()
+}))
+
+jest.mock('../../src/chat/chatClientFactory', () => ({
+  createChatWebSocketClient: jest.fn()
+}))
+
+const makeFakeClient = () => {
+  let stateListener: ((state: string) => void) | null = null
+  let online = false
+
+  return {
+    connect: jest.fn(),
+    close: jest.fn(),
+    send: jest.fn(() => online),
+    onMessage: jest.fn(() => jest.fn()),
+    onStateChange: jest.fn((listener: (state: string) => void) => {
+      stateListener = listener
+
+      return jest.fn()
+    }),
+    goOnline() {
+      online = true
+      stateListener?.('open')
+    }
+  }
+}
+
+describe('useChatRoom', () => {
+  afterEach(() => { jest.clearAllMocks() })
+
+  it('marks the channel read on open', async() => {
+    (fetchChatHistory as jest.Mock).mockResolvedValue({ data: { items: [] }, status: 200 })
+    ;(markChatRead as jest.Mock).mockResolvedValue({ success: true })
+    ;(createChatWebSocketClient as jest.Mock).mockReturnValue(makeFakeClient())
+
+    const { result } = renderHook(() => useChatRoom('chan'))
+
+    await waitFor(() => { expect(result.current.loading).toBe(false) })
+    expect(markChatRead).toHaveBeenCalledWith('chan', expect.anything())
+  })
+
+  it('queues a send made while offline and flushes it on reconnect', async() => {
+    const fakeClient = makeFakeClient()
+    ;(fetchChatHistory as jest.Mock).mockResolvedValue({ data: { items: [] }, status: 200 })
+    ;(markChatRead as jest.Mock).mockResolvedValue({})
+    ;(createChatWebSocketClient as jest.Mock).mockReturnValue(fakeClient)
+
+    const { result } = renderHook(() => useChatRoom('chan'))
+    await waitFor(() => { expect(result.current.loading).toBe(false) })
+
+    act(() => { result.current.send('hello') })
+    expect(fakeClient.send).toHaveBeenCalledTimes(1)
+
+    act(() => { fakeClient.goOnline() })
+    expect(fakeClient.send).toHaveBeenCalledTimes(2)
+    expect(fakeClient.send).toHaveBeenLastCalledWith({ channelId: 'chan', content: 'hello' })
+  })
+})

--- a/clients/mobile/__tests__/chat/useChatRoom.test.ts
+++ b/clients/mobile/__tests__/chat/useChatRoom.test.ts
@@ -41,7 +41,7 @@ describe('useChatRoom', () => {
   afterEach(() => { jest.clearAllMocks() })
 
   it('marks the channel read on open', async() => {
-    (fetchChatHistory as jest.Mock).mockResolvedValue({ data: { items: [] }, status: 200 })
+    (fetchChatHistory as jest.Mock).mockResolvedValue({ data: { channel: null, page: { items: [] } }, status: 200 })
     ;(markChatRead as jest.Mock).mockResolvedValue({ success: true })
     ;(createChatWebSocketClient as jest.Mock).mockReturnValue(makeFakeClient())
 
@@ -53,7 +53,7 @@ describe('useChatRoom', () => {
 
   it('queues a send made while offline and flushes it on reconnect', async() => {
     const fakeClient = makeFakeClient()
-    ;(fetchChatHistory as jest.Mock).mockResolvedValue({ data: { items: [] }, status: 200 })
+    ;(fetchChatHistory as jest.Mock).mockResolvedValue({ data: { channel: null, page: { items: [] } }, status: 200 })
     ;(markChatRead as jest.Mock).mockResolvedValue({})
     ;(createChatWebSocketClient as jest.Mock).mockReturnValue(fakeClient)
 

--- a/clients/mobile/app.config.ts
+++ b/clients/mobile/app.config.ts
@@ -46,6 +46,9 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
     ...config,
     extra: {
       ...ENV_VARS[environmentConfigs.APP_ENV],
+      // Optional (not in the required env set): chat is gated by EXPO_PUBLIC_CHAT_ENABLED, so a build
+      // without a WebSocket endpoint must still succeed. createChatWebSocketClient returns null when unset.
+      WEBSOCKET_URL: process.env.WEBSOCKET_URL,
       eas: {
         projectId: environmentConfigs.EAS_PROJECT_ID?.trim()
       }

--- a/clients/mobile/app.config.ts
+++ b/clients/mobile/app.config.ts
@@ -49,6 +49,8 @@ export default ({ config }: { config: ExpoConfig }): ExpoConfig => {
       // Optional (not in the required env set): chat is gated by EXPO_PUBLIC_CHAT_ENABLED, so a build
       // without a WebSocket endpoint must still succeed. createChatWebSocketClient returns null when unset.
       WEBSOCKET_URL: process.env.WEBSOCKET_URL,
+      // Build-time rollout flag: gates chat routes and entry points (see isChatEnabled).
+      CHAT_ENABLED: process.env.EXPO_PUBLIC_CHAT_ENABLED,
       eas: {
         projectId: environmentConfigs.EAS_PROJECT_ID?.trim()
       }

--- a/clients/mobile/src/chat/ChatInbox.tsx
+++ b/clients/mobile/src/chat/ChatInbox.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { View, Text, FlatList, TouchableOpacity, StyleSheet, RefreshControl } from 'react-native'
+import { useNavigation } from '@react-navigation/native'
+import { useTheme } from '../setup/theme/hooks/useTheme'
+import type { Theme } from '../setup/theme'
+import { SCREENS } from '../setup/constant/screens'
+import type { ChatInboxNavigationProp } from '../setup/navigation/navigationTypes'
+import StateAwareRenderer from '../components/StateAwareRenderer'
+import { formattedDate } from '../utility/formatting'
+import { ChatRole } from '../../../../commons/dto/ChatDTO'
+import { useChatInbox } from './useChatInbox'
+import type { ChatInboxItem } from './chatTypes'
+
+// The caller chats with the opposite participant: a seeker's channels are with donors and vice versa.
+const counterpartLabel = (role: ChatInboxItem['role']): string =>
+  (role === ChatRole.SEEKER ? 'Chat with donor' : 'Chat with seeker')
+
+const ChatInbox = () => {
+  const styles = createStyles(useTheme())
+  const navigation = useNavigation<ChatInboxNavigationProp>()
+  const { channels, loading, error, refresh, markRead } = useChatInbox()
+
+  const openChannel = (channel: ChatInboxItem): void => {
+    if (channel.unread) void markRead(channel.channelId)
+    navigation.navigate(SCREENS.CHAT_ROOM, { channelId: channel.channelId })
+  }
+
+  const ViewToRender = () =>
+    <FlatList
+      data={channels}
+      keyExtractor={(item) => item.channelId}
+      contentContainerStyle={styles.list}
+      refreshControl={
+        <RefreshControl refreshing={loading} onRefresh={() => { void refresh() }} />
+      }
+      ListEmptyComponent={
+        <View style={styles.emptyContainer}>
+          <Text style={styles.emptyText}>No conversations yet.</Text>
+        </View>
+      }
+      renderItem={({ item }) => (
+        <TouchableOpacity style={styles.row} onPress={() => { openChannel(item) }}>
+          <View style={styles.rowText}>
+            <Text style={[styles.title, item.unread && styles.titleUnread]}>
+              {counterpartLabel(item.role)}
+            </Text>
+            {item.lastMessageAt !== undefined && (
+              <Text style={styles.subtitle}>{formattedDate(item.lastMessageAt)}</Text>
+            )}
+          </View>
+          {item.unread && <View style={styles.unreadBadge} testID="unread-badge" />}
+        </TouchableOpacity>
+      )}
+    />
+
+  return (
+    <View style={styles.container}>
+      <StateAwareRenderer
+        loading={loading && channels.length === 0}
+        errorMessage={error}
+        data={channels}
+        showEmptyMessageForEmptyArray={false}
+        ViewComponent={ViewToRender}
+      />
+    </View>
+  )
+}
+
+const createStyles = (theme: Theme): ReturnType<typeof StyleSheet.create> => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.white
+  },
+  list: {
+    flexGrow: 1
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 16,
+    paddingHorizontal: 16,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.extraLightGray
+  },
+  rowText: {
+    flex: 1
+  },
+  title: {
+    fontSize: 16,
+    color: theme.colors.textPrimary
+  },
+  titleUnread: {
+    fontWeight: 'bold'
+  },
+  subtitle: {
+    fontSize: 12,
+    color: theme.colors.textSecondary,
+    marginTop: 4
+  },
+  unreadBadge: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: theme.colors.primary,
+    marginLeft: 12
+  },
+  emptyContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center'
+  },
+  emptyText: {
+    fontSize: 16,
+    color: theme.colors.grey
+  }
+})
+
+export default ChatInbox

--- a/clients/mobile/src/chat/ChatRoom.tsx
+++ b/clients/mobile/src/chat/ChatRoom.tsx
@@ -1,0 +1,177 @@
+import React, { useState } from 'react'
+import {
+  View,
+  Text,
+  FlatList,
+  TextInput,
+  TouchableOpacity,
+  StyleSheet,
+  KeyboardAvoidingView,
+  Platform
+} from 'react-native'
+import { useRoute } from '@react-navigation/native'
+import { useTheme } from '../setup/theme/hooks/useTheme'
+import type { Theme } from '../setup/theme'
+import type { ChatRoomRouteProp } from '../setup/navigation/navigationTypes'
+import { useUserProfile } from '../userWorkflow/context/UserProfileContext'
+import StateAwareRenderer from '../components/StateAwareRenderer'
+import { ChatChannelStatus } from './chatTypes'
+import type { ChatMessageDTO } from './chatTypes'
+import { useChatRoom } from './useChatRoom'
+import ChatRoomHeader from './ChatRoomHeader'
+
+const ChatRoom = () => {
+  const styles = createStyles(useTheme())
+  const { channelId } = useRoute<ChatRoomRouteProp>().params
+  const { userProfile } = useUserProfile()
+  const { messages, channel, loading, error, send } = useChatRoom(channelId)
+  const [draft, setDraft] = useState('')
+
+  // Only an explicitly OPEN channel accepts messages; a LOCKED channel shows a read-only banner and
+  // an unknown (null) channel shows neither, so we never invite a send that would fail server-side.
+  const isOpen = channel?.status === ChatChannelStatus.OPEN
+  const isLocked = channel?.status === ChatChannelStatus.LOCKED
+
+  const handleSend = (): void => {
+    const content = draft.trim()
+    if (content === '') return
+    send(content)
+    setDraft('')
+  }
+
+  const renderBubble = ({ item }: { item: ChatMessageDTO }) => {
+    const isOwn = item.senderId === userProfile.userId
+
+    return (
+      <View style={[styles.bubble, isOwn ? styles.bubbleOwn : styles.bubbleOther]}>
+        <Text style={isOwn ? styles.bubbleTextOwn : styles.bubbleText}>{item.content}</Text>
+      </View>
+    )
+  }
+
+  const ViewToRender = () =>
+    <FlatList
+      data={messages}
+      keyExtractor={(item) => item.messageId}
+      renderItem={renderBubble}
+      inverted
+      contentContainerStyle={styles.messageList}
+    />
+
+  return (
+    <KeyboardAvoidingView
+      style={styles.container}
+      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+    >
+      {channel !== null && <ChatRoomHeader context={channel.context} />}
+
+      <View style={styles.body}>
+        <StateAwareRenderer
+          loading={loading && messages.length === 0}
+          errorMessage={error}
+          data={messages}
+          ViewComponent={ViewToRender}
+        />
+      </View>
+
+      {isLocked && <View style={styles.lockedBanner}>
+        <Text style={styles.lockedText}>This conversation is closed. You can no longer send messages.</Text>
+      </View>}
+
+      {isOpen && <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          value={draft}
+          onChangeText={setDraft}
+          placeholder="Type a message"
+          multiline
+        />
+        <TouchableOpacity
+          style={[styles.sendButton, draft.trim() === '' && styles.sendButtonDisabled]}
+          onPress={handleSend}
+          disabled={draft.trim() === ''}
+        >
+          <Text style={styles.sendText}>Send</Text>
+        </TouchableOpacity>
+      </View>}
+    </KeyboardAvoidingView>
+  )
+}
+
+const createStyles = (theme: Theme): ReturnType<typeof StyleSheet.create> => StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: theme.colors.white
+  },
+  body: {
+    flex: 1
+  },
+  messageList: {
+    padding: 16,
+    flexGrow: 1
+  },
+  bubble: {
+    maxWidth: '80%',
+    paddingVertical: 8,
+    paddingHorizontal: 12,
+    borderRadius: 12,
+    marginVertical: 4
+  },
+  bubbleOwn: {
+    alignSelf: 'flex-end',
+    backgroundColor: theme.colors.primary
+  },
+  bubbleOther: {
+    alignSelf: 'flex-start',
+    backgroundColor: theme.colors.greyBG
+  },
+  bubbleText: {
+    color: theme.colors.textPrimary
+  },
+  bubbleTextOwn: {
+    color: theme.colors.white
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    padding: 8,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.extraLightGray
+  },
+  input: {
+    flex: 1,
+    maxHeight: 100,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: theme.colors.extraLightGray,
+    borderRadius: 20,
+    color: theme.colors.textPrimary
+  },
+  sendButton: {
+    marginLeft: 8,
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderRadius: 20,
+    backgroundColor: theme.colors.primary
+  },
+  sendButtonDisabled: {
+    opacity: 0.5
+  },
+  sendText: {
+    color: theme.colors.white,
+    fontWeight: 'bold'
+  },
+  lockedBanner: {
+    padding: 16,
+    backgroundColor: theme.colors.greyBG,
+    borderTopWidth: 1,
+    borderTopColor: theme.colors.extraLightGray
+  },
+  lockedText: {
+    textAlign: 'center',
+    color: theme.colors.textSecondary
+  }
+})
+
+export default ChatRoom

--- a/clients/mobile/src/chat/ChatRoomHeader.tsx
+++ b/clients/mobile/src/chat/ChatRoomHeader.tsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { View, Text, StyleSheet } from 'react-native'
+import { useTheme } from '../setup/theme/hooks/useTheme'
+import type { Theme } from '../setup/theme'
+import { formattedDate } from '../utility/formatting'
+import type { ChatContextSnapshot } from './chatTypes'
+
+type ChatRoomHeaderProps = {
+  context: ChatContextSnapshot;
+}
+
+// Renders the request context snapshotted onto the channel at creation, so the header shows on a
+// cold-start deep-link without fetching the donation post.
+const ChatRoomHeader = ({ context }: ChatRoomHeaderProps) => {
+  const styles = createStyles(useTheme())
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.titleRow}>
+        <Text style={styles.bloodGroup}>{context.requestedBloodGroup}</Text>
+        <Text style={styles.urgency}>{context.urgencyLevel}</Text>
+      </View>
+      <Text style={styles.detail}>{context.location}</Text>
+      <Text style={styles.detail}>{formattedDate(context.donationDateTime)}</Text>
+    </View>
+  )
+}
+
+const createStyles = (theme: Theme): ReturnType<typeof StyleSheet.create> => StyleSheet.create({
+  container: {
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    backgroundColor: theme.colors.white,
+    borderBottomWidth: 1,
+    borderBottomColor: theme.colors.extraLightGray
+  },
+  titleRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8
+  },
+  bloodGroup: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    color: theme.colors.primary
+  },
+  urgency: {
+    fontSize: 13,
+    textTransform: 'capitalize',
+    color: theme.colors.textSecondary
+  },
+  detail: {
+    fontSize: 13,
+    color: theme.colors.textSecondary,
+    marginTop: 2
+  }
+})
+
+export default ChatRoomHeader

--- a/clients/mobile/src/chat/ChatWebSocketClient.ts
+++ b/clients/mobile/src/chat/ChatWebSocketClient.ts
@@ -1,0 +1,161 @@
+import { log } from '../utility/logger'
+import type { ChatMessageDTO, ChatSendPayload } from './chatTypes'
+
+export type ChatSocketState = 'connecting' | 'open' | 'closed'
+
+// Minimal structural type so a real RN WebSocket and a test double are interchangeable.
+export type WebSocketLike = {
+  send: (data: string) => void;
+  close: () => void;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  onclose: (() => void) | null;
+  onerror: ((error: unknown) => void) | null;
+}
+
+type MessageListener = (message: ChatMessageDTO) => void
+type StateListener = (state: ChatSocketState) => void
+
+export type ChatWebSocketOptions = {
+  url: string;
+  getToken: () => Promise<string | undefined>;
+  webSocketFactory?: (url: string) => WebSocketLike;
+  baseReconnectDelayMs?: number;
+  maxReconnectDelayMs?: number;
+}
+
+const DEFAULT_BASE_RECONNECT_DELAY_MS = 1000
+const DEFAULT_MAX_RECONNECT_DELAY_MS = 30000
+
+// Authenticated WebSocket client for chat with exponential-backoff reconnection. The token rides the
+// query string because WebSocket clients cannot set headers on $connect (the $connect authorizer
+// reads route.request.querystring.token). A live-endpoint connection is verified manually on a
+// deployed dev environment; the unit tests cover reconnection/backoff with an injected socket.
+export class ChatWebSocketClient {
+  private readonly url: string
+  private readonly getToken: () => Promise<string | undefined>
+  private readonly webSocketFactory: (url: string) => WebSocketLike
+  private readonly baseReconnectDelayMs: number
+  private readonly maxReconnectDelayMs: number
+
+  private socket: WebSocketLike | null = null
+  private reconnectAttempts = 0
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private closedByClient = false
+  private state: ChatSocketState = 'closed'
+  private readonly messageListeners = new Set<MessageListener>()
+  private readonly stateListeners = new Set<StateListener>()
+
+  constructor(options: ChatWebSocketOptions) {
+    this.url = options.url
+    this.getToken = options.getToken
+    this.webSocketFactory = options.webSocketFactory
+      ?? ((url) => new globalThis.WebSocket(url) as unknown as WebSocketLike)
+    this.baseReconnectDelayMs = options.baseReconnectDelayMs ?? DEFAULT_BASE_RECONNECT_DELAY_MS
+    this.maxReconnectDelayMs = options.maxReconnectDelayMs ?? DEFAULT_MAX_RECONNECT_DELAY_MS
+  }
+
+  async connect(): Promise<void> {
+    this.closedByClient = false
+    this.clearReconnectTimer()
+    this.setState('connecting')
+
+    const token = await this.getToken()
+    if (token === undefined || token === '') {
+      log.error('chat websocket: no auth token, scheduling reconnect')
+      this.scheduleReconnect()
+
+      return
+    }
+
+    const separator = this.url.includes('?') ? '&' : '?'
+    const socket = this.webSocketFactory(`${this.url}${separator}token=${encodeURIComponent(token)}`)
+    this.socket = socket
+
+    socket.onopen = () => {
+      this.reconnectAttempts = 0
+      this.setState('open')
+    }
+    socket.onmessage = (event) => { this.handleMessage(event.data) }
+    socket.onerror = (error) => { log.error('chat websocket error', error) }
+    socket.onclose = () => {
+      this.socket = null
+      this.setState('closed')
+      if (!this.closedByClient) {
+        this.scheduleReconnect()
+      }
+    }
+  }
+
+  // Returns false when the socket is not open so the caller can queue the message for a later flush.
+  send(payload: ChatSendPayload): boolean {
+    if (this.socket === null || this.state !== 'open') {
+      return false
+    }
+    try {
+      this.socket.send(JSON.stringify({ action: 'sendMessage', ...payload }))
+
+      return true
+    } catch (error) {
+      log.error('chat websocket: send failed', error)
+
+      return false
+    }
+  }
+
+  close(): void {
+    this.closedByClient = true
+    this.clearReconnectTimer()
+    this.socket?.close()
+    this.socket = null
+    this.setState('closed')
+  }
+
+  getState(): ChatSocketState {
+    return this.state
+  }
+
+  onMessage(listener: MessageListener): () => void {
+    this.messageListeners.add(listener)
+
+    return () => { this.messageListeners.delete(listener) }
+  }
+
+  onStateChange(listener: StateListener): () => void {
+    this.stateListeners.add(listener)
+
+    return () => { this.stateListeners.delete(listener) }
+  }
+
+  private handleMessage(raw: string): void {
+    try {
+      const message = JSON.parse(raw) as ChatMessageDTO
+      this.messageListeners.forEach((listener) => { listener(message) })
+    } catch (error) {
+      log.error('chat websocket: failed to parse message', error)
+    }
+  }
+
+  private scheduleReconnect(): void {
+    this.clearReconnectTimer()
+    const delay = Math.min(
+      this.baseReconnectDelayMs * 2 ** this.reconnectAttempts,
+      this.maxReconnectDelayMs
+    )
+    this.reconnectAttempts += 1
+    this.reconnectTimer = setTimeout(() => { void this.connect() }, delay)
+  }
+
+  private clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  private setState(state: ChatSocketState): void {
+    if (this.state === state) return
+    this.state = state
+    this.stateListeners.forEach((listener) => { listener(state) })
+  }
+}

--- a/clients/mobile/src/chat/chatClientFactory.ts
+++ b/clients/mobile/src/chat/chatClientFactory.ts
@@ -1,0 +1,18 @@
+import Constants from 'expo-constants'
+import authService from '../authentication/services/authService'
+import { ChatWebSocketClient } from './ChatWebSocketClient'
+
+// Builds a client wired to the deployed WebSocket endpoint and the Cognito access token (the
+// $connect authorizer verifies the access token). Returns null when no endpoint is configured, so a
+// build without WEBSOCKET_URL (chat gated off) degrades to no live socket rather than crashing.
+export const createChatWebSocketClient = (): ChatWebSocketClient | null => {
+  const { WEBSOCKET_URL } = (Constants.expoConfig?.extra ?? {}) as { WEBSOCKET_URL?: string }
+  if (WEBSOCKET_URL === undefined || WEBSOCKET_URL === '') {
+    return null
+  }
+
+  return new ChatWebSocketClient({
+    url: WEBSOCKET_URL,
+    getToken: async() => (await authService.fetchSession()).accessToken
+  })
+}

--- a/clients/mobile/src/chat/chatConfig.ts
+++ b/clients/mobile/src/chat/chatConfig.ts
@@ -1,0 +1,10 @@
+import Constants from 'expo-constants'
+
+// Build-time rollout flag. Chat navigation routes and entry-point buttons are shown only when
+// EXPO_PUBLIC_CHAT_ENABLED is 'true' (surfaced as CHAT_ENABLED in app.config extra). Any other
+// value (including unset) keeps chat fully hidden.
+export const isChatEnabled = (): boolean => {
+  const { CHAT_ENABLED } = (Constants.expoConfig?.extra ?? {}) as { CHAT_ENABLED?: string }
+
+  return CHAT_ENABLED === 'true'
+}

--- a/clients/mobile/src/chat/chatHelpers.ts
+++ b/clients/mobile/src/chat/chatHelpers.ts
@@ -1,0 +1,18 @@
+import type { ChatInboxItem, ChatMembershipDTO } from './chatTypes'
+
+// Unread is derived client-side: a channel is unread when it has activity newer than the caller's
+// own lastReadAt marker (ISO timestamps sort lexicographically). Not a read receipt.
+export const isUnread = (lastMessageAt?: string, lastReadAt?: string): boolean => {
+  if (lastMessageAt === undefined || lastMessageAt === '') return false
+  if (lastReadAt === undefined || lastReadAt === '') return true
+
+  return lastMessageAt > lastReadAt
+}
+
+export const toInboxItem = (membership: ChatMembershipDTO): ChatInboxItem => ({
+  channelId: membership.channelId,
+  role: membership.role,
+  lastMessageAt: membership.lastMessageAt,
+  lastReadAt: membership.lastReadAt,
+  unread: isUnread(membership.lastMessageAt, membership.lastReadAt)
+})

--- a/clients/mobile/src/chat/chatService.ts
+++ b/clients/mobile/src/chat/chatService.ts
@@ -1,0 +1,55 @@
+import type { HttpClient } from '../setup/clients/HttpClient'
+import type { ApiResponse } from '../setup/clients/response'
+import type { ChatHistoryPage, ChatMembershipDTO } from './chatTypes'
+
+export type ChatChannelsResponse = ApiResponse<ChatMembershipDTO[]>
+export type ChatHistoryResponse = ApiResponse<ChatHistoryPage>
+
+// Lists the caller's chat channels (their membership items). Claim-only GET.
+export const fetchChatChannels = async(httpClient: HttpClient): Promise<ChatChannelsResponse> => {
+  try {
+    const response = await httpClient.get<ChatChannelsResponse>('/chat/channels')
+
+    return { data: response.data, status: response.status }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.'
+    throw new Error(errorMessage)
+  }
+}
+
+// Newest-first, paginated history for a channel. The composite channelId and the opaque cursor ride
+// the JSON body (a path param would need '#' encoding and the cursor cannot ride a query string).
+export const fetchChatHistory = async(
+  channelId: string,
+  httpClient: HttpClient,
+  limit?: number,
+  exclusiveStartKey?: Record<string, unknown>
+): Promise<ChatHistoryResponse> => {
+  try {
+    const body: Record<string, unknown> = { channelId }
+    if (limit !== undefined) body.limit = limit
+    if (exclusiveStartKey !== undefined) body.exclusiveStartKey = exclusiveStartKey
+
+    const response = await httpClient.post<ChatHistoryResponse>('/chat/history', body)
+
+    return { data: response.data, status: response.status }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.'
+    throw new Error(errorMessage)
+  }
+}
+
+// Updates the caller's own lastReadAt marker on the channel.
+export const markChatRead = async(
+  channelId: string,
+  httpClient: HttpClient
+): Promise<ApiResponse> => {
+  try {
+    const response = await httpClient.patch<ApiResponse>('/chat/read', { channelId })
+
+    return { message: response.message, status: response.status, success: response.success }
+  } catch (error) {
+    const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred.'
+    throw new Error(errorMessage)
+  }
+}

--- a/clients/mobile/src/chat/chatService.ts
+++ b/clients/mobile/src/chat/chatService.ts
@@ -1,9 +1,9 @@
 import type { HttpClient } from '../setup/clients/HttpClient'
 import type { ApiResponse } from '../setup/clients/response'
-import type { ChatHistoryPage, ChatMembershipDTO } from './chatTypes'
+import type { ChatHistoryResult, ChatMembershipDTO } from './chatTypes'
 
 export type ChatChannelsResponse = ApiResponse<ChatMembershipDTO[]>
-export type ChatHistoryResponse = ApiResponse<ChatHistoryPage>
+export type ChatHistoryResponse = ApiResponse<ChatHistoryResult>
 
 // Lists the caller's chat channels (their membership items). Claim-only GET.
 export const fetchChatChannels = async(httpClient: HttpClient): Promise<ChatChannelsResponse> => {

--- a/clients/mobile/src/chat/chatTypes.ts
+++ b/clients/mobile/src/chat/chatTypes.ts
@@ -1,9 +1,27 @@
-import type { ChatMembershipDTO, ChatMessageDTO } from '../../../../commons/dto/ChatDTO'
+import type {
+  ChatChannelStatus,
+  ChatContextSnapshot,
+  ChatMembershipDTO,
+  ChatMessageDTO
+} from '../../../../commons/dto/ChatDTO'
 
 // A page of chat history mirrors the backend ChatHistoryPage port (newest-first items + cursor).
 export type ChatHistoryPage = {
   items: ChatMessageDTO[];
   lastEvaluatedKey?: Record<string, unknown>;
+}
+
+// The channel's status and snapshotted request context, returned alongside history so the chat room
+// renders its header and locked banner on a cold-start deep-link without a separate post fetch.
+export type ChatChannelContext = {
+  status: ChatChannelStatus;
+  context: ChatContextSnapshot;
+}
+
+// getHistory returns the channel context plus a page of messages in one call.
+export type ChatHistoryResult = {
+  channel: ChatChannelContext | null;
+  page: ChatHistoryPage;
 }
 
 // An inbox row derived from the caller's membership item: unread is computed client-side from
@@ -23,4 +41,5 @@ export type ChatSendPayload = {
   content: string;
 }
 
-export type { ChatMembershipDTO, ChatMessageDTO }
+export { ChatChannelStatus } from '../../../../commons/dto/ChatDTO'
+export type { ChatContextSnapshot, ChatMembershipDTO, ChatMessageDTO }

--- a/clients/mobile/src/chat/chatTypes.ts
+++ b/clients/mobile/src/chat/chatTypes.ts
@@ -1,0 +1,26 @@
+import type { ChatMembershipDTO, ChatMessageDTO } from '../../../../commons/dto/ChatDTO'
+
+// A page of chat history mirrors the backend ChatHistoryPage port (newest-first items + cursor).
+export type ChatHistoryPage = {
+  items: ChatMessageDTO[];
+  lastEvaluatedKey?: Record<string, unknown>;
+}
+
+// An inbox row derived from the caller's membership item: unread is computed client-side from
+// lastMessageAt vs the caller's private lastReadAt (not a read receipt).
+export type ChatInboxItem = {
+  channelId: string;
+  role: ChatMembershipDTO['role'];
+  lastMessageAt?: string;
+  lastReadAt?: string;
+  unread: boolean;
+}
+
+// Body the client sends on the WebSocket sendMessage route. `action` drives the API Gateway route
+// selection ($request.body.action); the handler reads channelId + content.
+export type ChatSendPayload = {
+  channelId: string;
+  content: string;
+}
+
+export type { ChatMembershipDTO, ChatMessageDTO }

--- a/clients/mobile/src/chat/useChatInbox.ts
+++ b/clients/mobile/src/chat/useChatInbox.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useFetchClient } from '../setup/clients/useFetchClient'
+import { fetchChatChannels, markChatRead } from './chatService'
+import { isUnread, toInboxItem } from './chatHelpers'
+import type { ChatInboxItem } from './chatTypes'
+
+type UseChatInboxResult = {
+  channels: ChatInboxItem[];
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  markRead: (channelId: string) => Promise<void>;
+}
+
+// Lists the caller's chat channels and derives the unread indicator from lastMessageAt vs the
+// caller's lastReadAt. markRead optimistically clears the badge by advancing the local lastReadAt.
+export const useChatInbox = (): UseChatInboxResult => {
+  // useFetchClient returns a fresh client each render, so hold it in a ref to keep the callbacks
+  // stable (depending on its identity would re-fire the effect on every render).
+  const fetchClient = useFetchClient()
+  const fetchClientRef = useRef(fetchClient)
+  fetchClientRef.current = fetchClient
+  const [channels, setChannels] = useState<ChatInboxItem[]>([])
+  const channelsRef = useRef(channels)
+  channelsRef.current = channels
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const refresh = useCallback(async(): Promise<void> => {
+    setLoading(true)
+    setError(null)
+    try {
+      const response = await fetchChatChannels(fetchClientRef.current)
+      setChannels((response.data ?? []).map(toInboxItem))
+    } catch (fetchError) {
+      const message = fetchError instanceof Error ? fetchError.message : 'Failed to load chats.'
+      setError(message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  const markRead = useCallback(async(channelId: string): Promise<void> => {
+    const readAt = new Date().toISOString()
+    const previousChannels = channelsRef.current
+    setChannels((previous) => previous.map((channel) => (
+      channel.channelId === channelId
+        ? { ...channel, lastReadAt: readAt, unread: isUnread(channel.lastMessageAt, readAt) }
+        : channel
+    )))
+    try {
+      await markChatRead(channelId, fetchClientRef.current)
+    } catch (markError) {
+      // Roll back the optimistic badge clear so it does not falsely show read.
+      setChannels(previousChannels)
+      throw markError
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+  }, [refresh])
+
+  return { channels, loading, error, refresh, markRead }
+}

--- a/clients/mobile/src/chat/useChatRoom.ts
+++ b/clients/mobile/src/chat/useChatRoom.ts
@@ -4,10 +4,11 @@ import { log } from '../utility/logger'
 import { createChatWebSocketClient } from './chatClientFactory'
 import type { ChatWebSocketClient } from './ChatWebSocketClient'
 import { fetchChatHistory, markChatRead } from './chatService'
-import type { ChatMessageDTO } from './chatTypes'
+import type { ChatChannelContext, ChatMessageDTO } from './chatTypes'
 
 type UseChatRoomResult = {
   messages: ChatMessageDTO[];
+  channel: ChatChannelContext | null;
   loading: boolean;
   error: string | null;
   connected: boolean;
@@ -24,6 +25,7 @@ export const useChatRoom = (channelId: string): UseChatRoomResult => {
   const fetchClientRef = useRef(fetchClient)
   fetchClientRef.current = fetchClient
   const [messages, setMessages] = useState<ChatMessageDTO[]>([])
+  const [channel, setChannel] = useState<ChatChannelContext | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [connected, setConnected] = useState(false)
@@ -55,7 +57,10 @@ export const useChatRoom = (channelId: string): UseChatRoomResult => {
       setError(null)
       try {
         const response = await fetchChatHistory(channelId, fetchClientRef.current)
-        if (active) setMessages(response.data?.items ?? [])
+        if (active) {
+          setMessages(response.data?.page.items ?? [])
+          setChannel(response.data?.channel ?? null)
+        }
       } catch (historyError) {
         if (active) {
           setError(historyError instanceof Error ? historyError.message : 'Failed to load messages.')
@@ -87,5 +92,5 @@ export const useChatRoom = (channelId: string): UseChatRoomResult => {
     }
   }, [channelId, flushQueue])
 
-  return { messages, loading, error, connected, send }
+  return { messages, channel, loading, error, connected, send }
 }

--- a/clients/mobile/src/chat/useChatRoom.ts
+++ b/clients/mobile/src/chat/useChatRoom.ts
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useFetchClient } from '../setup/clients/useFetchClient'
+import { log } from '../utility/logger'
+import { createChatWebSocketClient } from './chatClientFactory'
+import type { ChatWebSocketClient } from './ChatWebSocketClient'
+import { fetchChatHistory, markChatRead } from './chatService'
+import type { ChatMessageDTO } from './chatTypes'
+
+type UseChatRoomResult = {
+  messages: ChatMessageDTO[];
+  loading: boolean;
+  error: string | null;
+  connected: boolean;
+  send: (content: string) => void;
+}
+
+// Drives a single chat room: loads newest-first history over REST, opens the live WebSocket, marks
+// the channel read on open, appends fanned-out messages, and queues sends made while offline,
+// flushing them when the socket reconnects.
+export const useChatRoom = (channelId: string): UseChatRoomResult => {
+  // useFetchClient returns a fresh client each render; hold it in a ref so the socket-lifecycle
+  // effect keys only on channelId and does not tear down/reconnect on every render.
+  const fetchClient = useFetchClient()
+  const fetchClientRef = useRef(fetchClient)
+  fetchClientRef.current = fetchClient
+  const [messages, setMessages] = useState<ChatMessageDTO[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [connected, setConnected] = useState(false)
+  const clientRef = useRef<ChatWebSocketClient | null>(null)
+  const offlineQueueRef = useRef<string[]>([])
+
+  const flushQueue = useCallback((): void => {
+    const queued = offlineQueueRef.current
+    offlineQueueRef.current = []
+    queued.forEach((content) => {
+      const delivered = clientRef.current?.send({ channelId, content }) ?? false
+      if (!delivered) offlineQueueRef.current.push(content)
+    })
+  }, [channelId])
+
+  const send = useCallback((content: string): void => {
+    if (content === '') return
+    const delivered = clientRef.current?.send({ channelId, content }) ?? false
+    if (!delivered) offlineQueueRef.current.push(content)
+  }, [channelId])
+
+  useEffect(() => {
+    let active = true
+    const client = createChatWebSocketClient()
+    clientRef.current = client
+
+    const loadHistory = async(): Promise<void> => {
+      setLoading(true)
+      setError(null)
+      try {
+        const response = await fetchChatHistory(channelId, fetchClientRef.current)
+        if (active) setMessages(response.data?.items ?? [])
+      } catch (historyError) {
+        if (active) {
+          setError(historyError instanceof Error ? historyError.message : 'Failed to load messages.')
+        }
+      } finally {
+        if (active) setLoading(false)
+      }
+    }
+
+    void loadHistory()
+    void markChatRead(channelId, fetchClientRef.current).catch((markError) => { log.error(markError) })
+
+    const unsubscribers: Array<() => void> = []
+    if (client !== null) {
+      unsubscribers.push(client.onMessage((message) => {
+        setMessages((previous) => [message, ...previous])
+      }))
+      unsubscribers.push(client.onStateChange((state) => {
+        setConnected(state === 'open')
+        if (state === 'open') flushQueue()
+      }))
+      void client.connect()
+    }
+
+    return () => {
+      active = false
+      unsubscribers.forEach((unsubscribe) => { unsubscribe() })
+      client?.close()
+    }
+  }, [channelId, flushQueue])
+
+  return { messages, loading, error, connected, send }
+}

--- a/clients/mobile/src/components/donation/PostCard.tsx
+++ b/clients/mobile/src/components/donation/PostCard.tsx
@@ -46,6 +46,8 @@ type PostCardProps = {
   updateHandler?: (donationData: DonationData) => void;
   detailHandler?: (donationData: DonationData) => void;
   cancelHandler?: (donationData: DonationData) => void;
+  // When provided (chat rollout on), renders a Chat button opening this post's channel.
+  chatHandler?: (donationData: DonationData) => void;
   isLoading?: boolean;
 } & PostCardDisplayOptions
 
@@ -59,6 +61,7 @@ export const PostCard: React.FC<PostCardProps> = React.memo(({
   updateHandler,
   detailHandler,
   cancelHandler,
+  chatHandler,
   showContactNumber = false,
   showDescription = true,
   showTransportInfo = false,
@@ -365,6 +368,14 @@ export const PostCard: React.FC<PostCardProps> = React.memo(({
           onPress={() => { detailHandler?.(post) }}
         />
       </View>}
+      {chatHandler !== undefined && <View style={styles.buttonContainer}>
+        <Button
+          text="Chat"
+          buttonStyle={styles.chatButtonStyle}
+          textStyle={styles.chatTextStyle}
+          onPress={() => { chatHandler(post) }}
+        />
+      </View>}
     </View>
   )
 })
@@ -532,6 +543,13 @@ const createStyles = (theme: Theme) => StyleSheet.create({
   },
   textStyle: {
     color: theme.colors.textPrimary
+  },
+  chatButtonStyle: {
+    paddingVertical: 10,
+    backgroundColor: theme.colors.primary
+  },
+  chatTextStyle: {
+    color: theme.colors.white
   }
 })
 

--- a/clients/mobile/src/components/donation/Posts.tsx
+++ b/clients/mobile/src/components/donation/Posts.tsx
@@ -14,6 +14,7 @@ type PostsProps = {
   errorMessage: string | null;
   detailHandler?: (donationData: DonationData) => void;
   cancelPost?: (donationData: DonationData) => void;
+  chatHandler?: (donationData: DonationData) => void;
   refreshControl?: React.ReactElement;
   displayOptions?: PostCardDisplayOptions;
   emptyDataMessage?: string;
@@ -26,6 +27,7 @@ const Posts: React.FC<PostsProps> = ({
   errorMessage,
   detailHandler,
   cancelPost,
+  chatHandler,
   refreshControl,
   displayOptions,
   emptyDataMessage
@@ -40,6 +42,7 @@ const Posts: React.FC<PostsProps> = ({
         updateHandler={updatePost}
         detailHandler={detailHandler}
         cancelHandler={cancelPost}
+        chatHandler={chatHandler}
         {...displayOptions}
       />)}
     ListEmptyComponent={

--- a/clients/mobile/src/myActivity/MyActivityTab.tsx
+++ b/clients/mobile/src/myActivity/MyActivityTab.tsx
@@ -8,11 +8,29 @@ import Posts from '../components/donation/Posts'
 import { useMyActivityContext } from './context/useMyActivityContext'
 import Toast from '../components/toast'
 import React from 'react'
+import { useNavigation } from '@react-navigation/native'
+import { useUserProfile } from '../userWorkflow/context/UserProfileContext'
+import { isChatEnabled } from '../chat/chatConfig'
+import { buildChannelId } from '../../../../commons/dto/ChatDTO'
+import { SCREENS } from '../setup/constant/screens'
+import type { DonationData } from '../donationWorkflow/donationPosts/useDonationPosts'
+import type { MyActivityScreenNavigationProp } from '../setup/navigation/navigationTypes'
 
 const MyActivityTab = () => {
   const theme = useTheme()
   const { t } = useTranslation()
   const styles = createStyles(useTheme())
+  const navigation = useNavigation<MyActivityScreenNavigationProp>()
+  const { userProfile } = useUserProfile()
+
+  // The donor (current user) chats with the post's seeker about their own response.
+  const chatHandler = isChatEnabled()
+    ? (post: DonationData): void => {
+      navigation.navigate(SCREENS.CHAT_ROOM, {
+        channelId: buildChannelId(post.seekerId, post.requestPostId, userProfile.userId)
+      })
+    }
+    : undefined
   const {
     donationPosts,
     errorMessage,
@@ -80,6 +98,7 @@ const MyActivityTab = () => {
           errorMessage={myResponsesError}
           emptyDataMessage={t('donationPosts.emptyMyDonationPosts')}
           detailHandler={myResponsesDetailHandler}
+          chatHandler={chatHandler}
           displayOptions={{ showOptions: false, showButton: true, showStatus: true }}
           refreshControl={
             <RefreshControl

--- a/clients/mobile/src/myActivity/myPosts/details/Detail.tsx
+++ b/clients/mobile/src/myActivity/myPosts/details/Detail.tsx
@@ -17,6 +17,8 @@ import {
   handleNotification
 } from '../../../setup/notification/scheduleNotification'
 import DonorResponses from '../donorResponses/DonorResponses'
+import { buildChannelId } from '../../../../../../commons/dto/ChatDTO'
+import { isChatEnabled } from '../../../chat/chatConfig'
 import type { TabConfig } from '../../types'
 import { useTheme } from '../../../setup/theme/hooks/useTheme'
 import type { Theme } from '../../../setup/theme'
@@ -61,6 +63,12 @@ const Detail = ({ navigation, route }: DetailProps) => {
 
   const handlePressDonor = (donorId: string): void => {
     navigation.navigate(SCREENS.DONOR_PROFILE, { donorId })
+  }
+
+  const handleChatWithDonor = (donorId: string): void => {
+    navigation.navigate(SCREENS.CHAT_ROOM, {
+      channelId: buildChannelId(data.seekerId, data.requestPostId, donorId)
+    })
   }
 
   const handleTabPress = (tab: string): void => {
@@ -171,6 +179,7 @@ const Detail = ({ navigation, route }: DetailProps) => {
         : <DonorResponses
           acceptedDonors={data.acceptedDonors}
           handlePressDonor={handlePressDonor}
+          onChatPress={isChatEnabled() ? handleChatWithDonor : undefined}
         />
       }
     </View>

--- a/clients/mobile/src/myActivity/myPosts/donorResponses/DonorResponses.tsx
+++ b/clients/mobile/src/myActivity/myPosts/donorResponses/DonorResponses.tsx
@@ -13,9 +13,11 @@ export type DonorItem = {
 type DonorResponsesProps = {
   acceptedDonors: DonorItem[];
   handlePressDonor: (item: string) => void;
+  // When provided (chat rollout on), each donor row gets a Chat button opening that donor's channel.
+  onChatPress?: (donorId: string) => void;
 }
 
-const DonorResponses = ({ acceptedDonors, handlePressDonor }: DonorResponsesProps) => {
+const DonorResponses = ({ acceptedDonors, handlePressDonor, onChatPress }: DonorResponsesProps) => {
   const styles = createStyles(useTheme())
 
   return (
@@ -44,6 +46,13 @@ const DonorResponses = ({ acceptedDonors, handlePressDonor }: DonorResponsesProp
                     <Text style={styles.name}>{item.donorName}</Text>
                     <Text style={styles.status}>New blood donor</Text>
                   </View>
+                  {onChatPress !== undefined && (
+                    <TouchableOpacity
+                      style={styles.chatButton}
+                      onPress={() => { onChatPress(item.donorId) }}>
+                      <Text style={styles.chatButtonText}>Chat</Text>
+                    </TouchableOpacity>
+                  )}
                   <Text style={styles.arrow}>&gt;</Text>
                 </TouchableOpacity>
               )}
@@ -115,6 +124,19 @@ const createStyles = (theme: Theme): ReturnType<typeof StyleSheet.create> =>
     arrow: {
       fontSize: 20,
       color: theme.colors.primary
+    },
+    chatButton: {
+      paddingHorizontal: 12,
+      paddingVertical: 6,
+      borderRadius: 16,
+      borderWidth: 1,
+      borderColor: theme.colors.primary,
+      marginRight: 12
+    },
+    chatButtonText: {
+      fontSize: 13,
+      color: theme.colors.primary,
+      fontWeight: '600'
     }
   })
 

--- a/clients/mobile/src/setup/constant/screens.ts
+++ b/clients/mobile/src/setup/constant/screens.ts
@@ -23,5 +23,6 @@ export enum SCREENS {
   DONOR_CONFIRMATION = 'DonorConfirmation',
   ABOUT = 'About',
   SETTINGS = 'Settings',
+  CHAT_ROOM = 'ChatRoom',
   NO_INTERNET = 'NoInternet'
 }

--- a/clients/mobile/src/setup/constant/screens.ts
+++ b/clients/mobile/src/setup/constant/screens.ts
@@ -23,6 +23,7 @@ export enum SCREENS {
   DONOR_CONFIRMATION = 'DonorConfirmation',
   ABOUT = 'About',
   SETTINGS = 'Settings',
+  CHAT_INBOX = 'ChatInbox',
   CHAT_ROOM = 'ChatRoom',
   NO_INTERNET = 'NoInternet'
 }

--- a/clients/mobile/src/setup/navigation/navigationTypes.ts
+++ b/clients/mobile/src/setup/navigation/navigationTypes.ts
@@ -35,6 +35,7 @@ export type RootStackParamList = {
   [SCREENS.DONOR_CONFIRMATION]: { requestPostId: string; donors: DonorItem[]; createdAt: string };
   [SCREENS.ABOUT]: undefined;
   [SCREENS.SETTINGS]: undefined;
+  [SCREENS.CHAT_INBOX]: undefined;
   [SCREENS.CHAT_ROOM]: { channelId: string };
   [SCREENS.NO_INTERNET]: undefined;
 }
@@ -60,6 +61,8 @@ export type OtpScreenNavigationProp = StackNavigationProp<RootStackParamList, SC
 export type AddPersonalInfoNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.ADD_PERSONAL_INFO>
 export type RequestStatusNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.REQUEST_STATUS>
 export type DonorConfirmationNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.DONOR_CONFIRMATION>
+export type ChatInboxNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.CHAT_INBOX>
+export type ChatRoomNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.CHAT_ROOM>
 export type NoInternetNavigationProp = StackNavigationProp<RootStackParamList, SCREENS.NO_INTERNET>
 
 export type OtpScreenRouteProp = RouteProp<RootStackParamList, SCREENS.OTP>
@@ -75,4 +78,5 @@ export type RequestStatusRouteProp = RouteProp<RootStackParamList, SCREENS.REQUE
 export type DonorConfirmationRouteProp = RouteProp<RootStackParamList, SCREENS.DONOR_CONFIRMATION>
 export type About = RouteProp<RootStackParamList, SCREENS.ABOUT>
 export type Settings = RouteProp<RootStackParamList, SCREENS.SETTINGS>
+export type ChatRoomRouteProp = RouteProp<RootStackParamList, SCREENS.CHAT_ROOM>
 export type NoInternetRouteProp = RouteProp<RootStackParamList, SCREENS.NO_INTERNET>

--- a/clients/mobile/src/setup/navigation/navigationTypes.ts
+++ b/clients/mobile/src/setup/navigation/navigationTypes.ts
@@ -35,6 +35,7 @@ export type RootStackParamList = {
   [SCREENS.DONOR_CONFIRMATION]: { requestPostId: string; donors: DonorItem[]; createdAt: string };
   [SCREENS.ABOUT]: undefined;
   [SCREENS.SETTINGS]: undefined;
+  [SCREENS.CHAT_ROOM]: { channelId: string };
   [SCREENS.NO_INTERNET]: undefined;
 }
 

--- a/clients/mobile/src/setup/navigation/routes.ts
+++ b/clients/mobile/src/setup/navigation/routes.ts
@@ -19,6 +19,28 @@ import Profile from '../../userWorkflow/userProfile/UI/Profile'
 import EditProfile from '../../userWorkflow/editUserProfile/UI/EditProfile'
 import RequestStatusScreen from '../../myActivity/donorTracking/bloodRequestStatus/RequestStatusScreen'
 import DonorConfirmationScreen from '../../myActivity/donorTracking/donorConfirmation/DonorConfirmationScreen'
+import ChatInbox from '../../chat/ChatInbox'
+import ChatRoom from '../../chat/ChatRoom'
+import { isChatEnabled } from '../../chat/chatConfig'
+
+// Chat routes are only registered when the rollout flag is on, so a flag-off build exposes no chat
+// screens at all (entry-point buttons are gated by the same flag).
+const chatRoutes = isChatEnabled()
+  ? [
+    {
+      name: SCREENS.CHAT_INBOX,
+      component: ChatInbox,
+      options: { headerShown: true, headerTitle: 'Messages' },
+      protected: true
+    },
+    {
+      name: SCREENS.CHAT_ROOM,
+      component: ChatRoom,
+      options: { headerShown: true, headerTitle: 'Chat' },
+      protected: true
+    }
+  ]
+  : []
 
 export const routes = [
   {
@@ -140,5 +162,6 @@ export const routes = [
     component: SettingsPage,
     options: { headerShown: true, headerTitle: 'Settings' },
     protected: true
-  }
+  },
+  ...chatRoutes
 ]

--- a/clients/mobile/src/setup/notification/NotificationProvider.tsx
+++ b/clients/mobile/src/setup/notification/NotificationProvider.tsx
@@ -17,9 +17,10 @@ type NotificationScreenConfig = {
   getParams?: (data: Record<string, unknown>) => NotificationData;
 }
 
-const SCREEN_FOR_NOTIFICATION: Partial<Record<string, NotificationScreenConfig>> = {
+export const SCREEN_FOR_NOTIFICATION: Partial<Record<string, NotificationScreenConfig>> = {
   BLOOD_REQ_POST: { screen: SCREENS.BLOOD_REQUEST_PREVIEW, getParams: (data) => ({ notificationData: data }) },
   REQ_ACCEPTED: { screen: SCREENS.DONOR_RESPONSE, getParams: (data) => ({ notificationData: data }) },
+  CHAT_MESSAGE: { screen: SCREENS.CHAT_ROOM, getParams: (data) => ({ channelId: data.channelId }) },
   [LOCAL_NOTIFICATION_TYPE.REQUEST_STATUS]: { screen: SCREENS.REQUEST_STATUS, getParams: (data) => ({ ...data }) },
   [LOCAL_NOTIFICATION_TYPE.REMINDER]: { screen: SCREENS.MY_ACTIVITY, getParams: (data) => ({ ...data }) }
 }

--- a/commons/dto/ChatDTO.ts
+++ b/commons/dto/ChatDTO.ts
@@ -32,6 +32,14 @@ export const parseChannelId = (
   }
 }
 
+// A channel's only participants are its seeker and its donor; used to enforce participant-only
+// access on the chat handlers.
+export const isChannelParticipant = (userId: string, channelId: string): boolean => {
+  const { seekerId, donorId } = parseChannelId(channelId)
+
+  return userId === seekerId || userId === donorId
+}
+
 // Request context snapshotted onto the channel at creation so the chat header
 // renders on a cold-start deep-link without a separate post fetch.
 export type ChatContextSnapshot = {

--- a/commons/dto/ChatDTO.ts
+++ b/commons/dto/ChatDTO.ts
@@ -1,0 +1,63 @@
+import type { BloodGroup, UrgencyType } from './DonationDTO'
+import type { DTO } from './DTOCommon'
+
+export enum ChatChannelStatus {
+  OPEN = 'OPEN',
+  LOCKED = 'LOCKED'
+}
+
+export enum ChatRole {
+  SEEKER = 'SEEKER',
+  DONOR = 'DONOR'
+}
+
+// Request context snapshotted onto the channel at creation so the chat header
+// renders on a cold-start deep-link without a separate post fetch.
+export type ChatContextSnapshot = {
+  requestedBloodGroup: BloodGroup;
+  urgencyLevel: UrgencyType;
+  donationDateTime: string;
+  location: string;
+}
+
+// Canonical channel keyed by (seekerId, requestPostId, donorId). channelId is the
+// composite `${seekerId}#${requestPostId}#${donorId}` carried on membership/message items.
+export type ChatChannelDTO = DTO & {
+  channelId: string;
+  seekerId: string;
+  requestPostId: string;
+  donorId: string;
+  status: ChatChannelStatus;
+  context: ChatContextSnapshot;
+  lastMessageAt?: string;
+  createdAt: string;
+}
+
+// One per participant, so each user lists their own channels by base-table PK query.
+// lastReadAt is the private per-user marker; unread is derived client-side from
+// lastMessageAt vs lastReadAt (not a read receipt).
+export type ChatMembershipDTO = DTO & {
+  userId: string;
+  channelId: string;
+  role: ChatRole;
+  lastReadAt?: string;
+  lastMessageAt?: string;
+  createdAt: string;
+}
+
+// messageId is a time-ordered key (ULID/ISO) used as the sort key for newest-first paging.
+export type ChatMessageDTO = DTO & {
+  channelId: string;
+  messageId: string;
+  senderId: string;
+  content: string;
+  ttl?: number;
+  createdAt: string;
+}
+
+// Live WebSocket connection, keyed by connectionId; GSI1 on userId for fanout.
+export type ChatConnectionDTO = DTO & {
+  connectionId: string;
+  userId: string;
+  createdAt: string;
+}

--- a/commons/dto/ChatDTO.ts
+++ b/commons/dto/ChatDTO.ts
@@ -11,6 +11,27 @@ export enum ChatRole {
   DONOR = 'DONOR'
 }
 
+// channelId is the composite identity carried on membership and message items. Defined here in
+// commons so both the framework-agnostic application layer and the AWS adapter layer share one
+// source of truth (the application layer must not import the AWS-layer models).
+export const buildChannelId = (seekerId: string, requestPostId: string, donorId: string): string =>
+  `${seekerId}#${requestPostId}#${donorId}`
+
+// Splits on the first two separators only, so the trailing donorId tolerates a '#' in the id; the
+// seekerId and requestPostId fields must remain '#'-free (true for Cognito ids and ULIDs).
+export const parseChannelId = (
+  channelId: string
+): { seekerId: string; requestPostId: string; donorId: string } => {
+  const firstSeparator = channelId.indexOf('#')
+  const secondSeparator = channelId.indexOf('#', firstSeparator + 1)
+
+  return {
+    seekerId: channelId.slice(0, firstSeparator),
+    requestPostId: channelId.slice(firstSeparator + 1, secondSeparator),
+    donorId: channelId.slice(secondSeparator + 1)
+  }
+}
+
 // Request context snapshotted onto the channel at creation so the chat header
 // renders on a cold-start deep-link without a separate post fetch.
 export type ChatContextSnapshot = {

--- a/commons/dto/NotificationDTO.ts
+++ b/commons/dto/NotificationDTO.ts
@@ -5,6 +5,7 @@ export enum NotificationType {
   BLOOD_REQ_POST = 'BLOOD_REQ_POST',
   REQ_ACCEPTED = 'REQ_ACCEPTED',
   REQ_IGNORED = 'REQ_IGNORED',
+  CHAT_MESSAGE = 'CHAT_MESSAGE',
   COMMON = 'COMMON'
 }
 export enum NotificationStatus {

--- a/commons/libs/config/config.ts
+++ b/commons/libs/config/config.ts
@@ -27,6 +27,10 @@ type AllConfig = {
   // Public post feed
   feedMaxRadiusKm: number;
   feedDefaultRadiusKm: number;
+
+  // Chat WebSocket $connect authorizer
+  cognitoUserPoolId: string;
+  cognitoClientId: string;
 }
 
 type ConfigSubset<T> = { [K in keyof T]: K extends keyof AllConfig ? AllConfig[K] : never }
@@ -72,7 +76,10 @@ export class Config<T extends ConfigSubset<T>> {
       feedMaxRadiusKm:
         Number(process.env.FEED_MAX_RADIUS_KM) as AllConfig['feedMaxRadiusKm'],
       feedDefaultRadiusKm:
-        Number(process.env.FEED_DEFAULT_RADIUS_KM) as AllConfig['feedDefaultRadiusKm']
+        Number(process.env.FEED_DEFAULT_RADIUS_KM) as AllConfig['feedDefaultRadiusKm'],
+
+      cognitoUserPoolId: process.env.COGNITO_USER_POOL_ID as AllConfig['cognitoUserPoolId'],
+      cognitoClientId: process.env.COGNITO_CLIENT_ID as AllConfig['cognitoClientId']
     }
   }
 

--- a/core/application/bloodDonationWorkflow/BloodDonationService.ts
+++ b/core/application/bloodDonationWorkflow/BloodDonationService.ts
@@ -33,11 +33,15 @@ import { NotificationStatus, NotificationType } from '../../../commons/dto/Notif
 import type { UpdateUserAttributes } from '../userWorkflow/Types'
 import type { LocationService } from '../userWorkflow/LocationService'
 import type { QueueModel } from '../models/queue/QueueModel'
+import type { ChatService } from '../chatWorkflow/ChatService'
 
 export class BloodDonationService {
   constructor(
     protected readonly bloodDonationRepository: BloodDonationRepository,
-    protected readonly logger: Logger
+    protected readonly logger: Logger,
+    // Optional so existing call sites keep working; supplied by the handlers that drive terminal
+    // transitions, to lock the request's chat channels.
+    protected readonly chatService?: ChatService
   ) {}
 
   async createBloodDonation(
@@ -250,6 +254,12 @@ export class BloodDonationService {
     }
     this.logger.info('updating donation status')
     await this.bloodDonationRepository.update(updateData)
+
+    // Cancel/expire have no per-donor REMOVE event to drive the lock pipe, so lock all of the
+    // request's channels here. Completion locks per-donor in completeDonationRequest instead.
+    if (status === DonationStatus.CANCELLED || status === DonationStatus.EXPIRED) {
+      await this.chatService?.lockChannelsForRequest(seekerId, requestPostId)
+    }
   }
 
   async checkAndUpdateDonationStatus(
@@ -343,6 +353,10 @@ export class BloodDonationService {
         locationService,
         minMonthsBetweenDonations
       )
+
+      // Lock this donor's chat channel last, so chat-locking is ancillary to the core completion
+      // (per-donor; the request stays the same).
+      await this.chatService?.lockChannel(seekerId, requestPostId, donorId)
     }
 
     await Promise.allSettled(

--- a/core/application/chatWorkflow/ChannelLockedError.ts
+++ b/core/application/chatWorkflow/ChannelLockedError.ts
@@ -1,0 +1,8 @@
+import ApplicationError from '../../../commons/libs/errors/ApplicationError'
+
+// Thrown when a message is sent to a channel that is not OPEN (locked or never opened).
+export default class ChannelLockedError extends ApplicationError {
+  constructor(message: string, errorCode: number) {
+    super('ChannelLockedError', message, errorCode)
+  }
+}

--- a/core/application/chatWorkflow/ChatRateLimitedError.ts
+++ b/core/application/chatWorkflow/ChatRateLimitedError.ts
@@ -1,0 +1,8 @@
+import ApplicationError from '../../../commons/libs/errors/ApplicationError'
+
+// Thrown when a channel exceeds the per-minute message rate limit.
+export default class ChatRateLimitedError extends ApplicationError {
+  constructor(message: string, errorCode: number) {
+    super('ChatRateLimitedError', message, errorCode)
+  }
+}

--- a/core/application/chatWorkflow/ChatService.ts
+++ b/core/application/chatWorkflow/ChatService.ts
@@ -1,0 +1,160 @@
+import {
+  buildChannelId,
+  parseChannelId,
+  ChatChannelStatus,
+  ChatRole
+} from '../../../commons/dto/ChatDTO'
+import type {
+  ChatChannelDTO,
+  ChatContextSnapshot,
+  ChatMembershipDTO,
+  ChatMessageDTO
+} from '../../../commons/dto/ChatDTO'
+import { GENERIC_CODES } from '../../../commons/libs/constants/GenericCodes'
+import type ChatRepository from '../models/policies/repositories/ChatRepository'
+import type { ChatHistoryPage } from '../models/policies/repositories/ChatRepository'
+import type ChatRateLimitRepository from '../models/policies/repositories/ChatRateLimitRepository'
+import type { Logger } from '../models/logger/Logger'
+import { generateUniqueID } from '../utils/idGenerator'
+import ChannelLockedError from './ChannelLockedError'
+import NotChannelParticipantError from './NotChannelParticipantError'
+import ChatRateLimitedError from './ChatRateLimitedError'
+
+// 60 messages per channel per rolling 60-second window.
+export const CHAT_RATE_LIMIT = 60
+export const CHAT_RATE_WINDOW_SECONDS = 60
+
+export type OpenChannelAttributes = {
+  seekerId: string;
+  requestPostId: string;
+  donorId: string;
+  context: ChatContextSnapshot;
+}
+
+export class ChatService {
+  constructor(
+    protected readonly chatRepository: ChatRepository,
+    protected readonly chatRateLimitRepository: ChatRateLimitRepository,
+    protected readonly logger: Logger
+  ) {}
+
+  // Create-or-reopen the channel and upsert both participants' membership items, snapshotting the
+  // request context so the chat header renders on a cold-start deep-link without a post fetch.
+  async openChannel(attributes: OpenChannelAttributes): Promise<ChatChannelDTO> {
+    const { seekerId, requestPostId, donorId, context } = attributes
+    const channelId = buildChannelId(seekerId, requestPostId, donorId)
+    const now = new Date().toISOString()
+
+    const channel = await this.chatRepository.upsertChannelOpen({
+      channelId,
+      seekerId,
+      requestPostId,
+      donorId,
+      status: ChatChannelStatus.OPEN,
+      context,
+      createdAt: now
+    })
+
+    await this.chatRepository.upsertMembership({
+      userId: seekerId,
+      channelId,
+      role: ChatRole.SEEKER,
+      createdAt: now
+    })
+    await this.chatRepository.upsertMembership({
+      userId: donorId,
+      channelId,
+      role: ChatRole.DONOR,
+      createdAt: now
+    })
+
+    return channel
+  }
+
+  // Reject non-participants and non-open channels, enforce the rate limit, persist the message and
+  // bump lastMessageAt on the channel and both membership items.
+  async sendMessage(
+    channelId: string,
+    senderId: string,
+    content: string
+  ): Promise<ChatMessageDTO> {
+    const { seekerId, requestPostId, donorId } = parseChannelId(channelId)
+    if (senderId !== seekerId && senderId !== donorId) {
+      throw new NotChannelParticipantError(
+        'Sender is not a participant of this channel.',
+        GENERIC_CODES.UNAUTHORIZED
+      )
+    }
+
+    const channel = await this.chatRepository.getChannel(seekerId, requestPostId, donorId)
+    if (channel === null || channel.status !== ChatChannelStatus.OPEN) {
+      throw new ChannelLockedError(
+        'Channel is not open for messaging.',
+        GENERIC_CODES.BAD_REQUEST
+      )
+    }
+
+    const allowed = await this.chatRateLimitRepository.tryConsume(
+      channelId,
+      CHAT_RATE_LIMIT,
+      CHAT_RATE_WINDOW_SECONDS
+    )
+    if (!allowed) {
+      throw new ChatRateLimitedError(
+        'Message rate limit exceeded for this channel.',
+        GENERIC_CODES.TOO_MANY_REQUESTS
+      )
+    }
+
+    const now = new Date().toISOString()
+    const savedMessage = await this.chatRepository.putMessage({
+      channelId,
+      messageId: generateUniqueID(),
+      senderId,
+      content,
+      createdAt: now
+    })
+
+    await this.chatRepository.updateChannelLastMessage(seekerId, requestPostId, donorId, now)
+    await this.chatRepository.updateMembershipLastMessage(seekerId, channelId, now)
+    await this.chatRepository.updateMembershipLastMessage(donorId, channelId, now)
+
+    return savedMessage
+  }
+
+  // Lists the caller's channels via their membership items: each carries the denormalized
+  // lastMessageAt and the caller's private lastReadAt, from which the client derives unread.
+  async listChannels(userId: string): Promise<ChatMembershipDTO[]> {
+    return this.chatRepository.listMembershipsByUser(userId)
+  }
+
+  async markRead(userId: string, channelId: string): Promise<void> {
+    await this.chatRepository.updateLastRead(userId, channelId, new Date().toISOString())
+  }
+
+  // Newest-first paginated message history for a channel.
+  async getHistory(
+    channelId: string,
+    limit?: number,
+    exclusiveStartKey?: Record<string, unknown>
+  ): Promise<ChatHistoryPage> {
+    return this.chatRepository.queryMessages(channelId, limit, exclusiveStartKey)
+  }
+
+  async lockChannel(seekerId: string, requestPostId: string, donorId: string): Promise<void> {
+    await this.chatRepository.lockChannel(seekerId, requestPostId, donorId)
+  }
+
+  // Locks every channel of a request (used by the cancel/expire in-service hooks where there is no
+  // per-donor REMOVE event to drive the lock pipe).
+  async lockChannelsForRequest(seekerId: string, requestPostId: string): Promise<void> {
+    const channels = await this.chatRepository.listChannelsForRequest(seekerId, requestPostId)
+    for (const channel of channels) {
+      await this.chatRepository.lockChannel(
+        channel.seekerId,
+        channel.requestPostId,
+        channel.donorId
+      )
+    }
+  }
+}

--- a/core/application/chatWorkflow/ChatService.ts
+++ b/core/application/chatWorkflow/ChatService.ts
@@ -31,6 +31,13 @@ export type OpenChannelAttributes = {
   context: ChatContextSnapshot;
 }
 
+// History plus the channel's status and snapshotted context, so the chat room renders its header
+// (and locked banner) on a cold-start deep-link from the same call, without a separate post fetch.
+export type ChatHistoryResult = {
+  channel: { status: ChatChannelStatus; context: ChatContextSnapshot } | null;
+  page: ChatHistoryPage;
+}
+
 export class ChatService {
   constructor(
     protected readonly chatRepository: ChatRepository,
@@ -132,13 +139,23 @@ export class ChatService {
     await this.chatRepository.updateLastRead(userId, channelId, new Date().toISOString())
   }
 
-  // Newest-first paginated message history for a channel.
+  // Newest-first paginated message history for a channel, plus the channel's status and context
+  // snapshot so the client renders the header and locked banner from this one call.
   async getHistory(
     channelId: string,
     limit?: number,
     exclusiveStartKey?: Record<string, unknown>
-  ): Promise<ChatHistoryPage> {
-    return this.chatRepository.queryMessages(channelId, limit, exclusiveStartKey)
+  ): Promise<ChatHistoryResult> {
+    const { seekerId, requestPostId, donorId } = parseChannelId(channelId)
+    const [channel, page] = await Promise.all([
+      this.chatRepository.getChannel(seekerId, requestPostId, donorId),
+      this.chatRepository.queryMessages(channelId, limit, exclusiveStartKey)
+    ])
+
+    return {
+      channel: channel === null ? null : { status: channel.status, context: channel.context },
+      page
+    }
   }
 
   async lockChannel(seekerId: string, requestPostId: string, donorId: string): Promise<void> {

--- a/core/application/chatWorkflow/NotChannelParticipantError.ts
+++ b/core/application/chatWorkflow/NotChannelParticipantError.ts
@@ -1,0 +1,8 @@
+import ApplicationError from '../../../commons/libs/errors/ApplicationError'
+
+// Thrown when a user who is neither the seeker nor the donor of a channel tries to act on it.
+export default class NotChannelParticipantError extends ApplicationError {
+  constructor(message: string, errorCode: number) {
+    super('NotChannelParticipantError', message, errorCode)
+  }
+}

--- a/core/application/models/policies/repositories/ChatConnectionRepository.ts
+++ b/core/application/models/policies/repositories/ChatConnectionRepository.ts
@@ -1,0 +1,10 @@
+import type { ChatConnectionDTO } from 'commons/dto/ChatDTO'
+
+// Live WebSocket connections, keyed by connectionId; queryByUserId fans a message out to
+// all of a recipient's open connections.
+type ChatConnectionRepository = {
+  put(connection: ChatConnectionDTO): Promise<ChatConnectionDTO>;
+  deleteByConnectionId(connectionId: string): Promise<void>;
+  queryByUserId(userId: string): Promise<ChatConnectionDTO[]>;
+}
+export default ChatConnectionRepository

--- a/core/application/models/policies/repositories/ChatConnectionRepository.ts
+++ b/core/application/models/policies/repositories/ChatConnectionRepository.ts
@@ -6,5 +6,8 @@ type ChatConnectionRepository = {
   put(connection: ChatConnectionDTO): Promise<ChatConnectionDTO>;
   deleteByConnectionId(connectionId: string): Promise<void>;
   queryByUserId(userId: string): Promise<ChatConnectionDTO[]>;
+  // Resolves the authenticated userId for a live connection: the $connect authorizer context is
+  // not propagated to message routes, so sendMessage looks the sender up by connectionId.
+  getByConnectionId(connectionId: string): Promise<ChatConnectionDTO | null>;
 }
 export default ChatConnectionRepository

--- a/core/application/models/policies/repositories/ChatRateLimitRepository.ts
+++ b/core/application/models/policies/repositories/ChatRateLimitRepository.ts
@@ -1,0 +1,7 @@
+// Atomic per-channel send rate limiter backed by a short-TTL DynamoDB counter item.
+// tryConsume increments the current window's counter under a conditional check and returns false
+// (without incrementing further) once the limit for the window is reached.
+type ChatRateLimitRepository = {
+  tryConsume(channelId: string, limit: number, windowSeconds: number): Promise<boolean>;
+}
+export default ChatRateLimitRepository

--- a/core/application/models/policies/repositories/ChatRepository.ts
+++ b/core/application/models/policies/repositories/ChatRepository.ts
@@ -1,0 +1,37 @@
+import type {
+  ChatChannelDTO,
+  ChatMembershipDTO,
+  ChatMessageDTO
+} from 'commons/dto/ChatDTO'
+
+export type ChatHistoryPage = {
+  items: ChatMessageDTO[];
+  lastEvaluatedKey?: Record<string, unknown>;
+}
+
+// Multi-entity port: the chat channel, its per-participant membership items, and messages
+// all live on the single table but are distinct item shapes, so this does not extend the
+// single-DTO Repository base.
+type ChatRepository = {
+  // Channel: create-or-reopen to OPEN, conditional lock, per-request listing for lock-all.
+  upsertChannelOpen(channel: ChatChannelDTO): Promise<ChatChannelDTO>;
+  lockChannel(seekerId: string, requestPostId: string, donorId: string): Promise<void>;
+  listChannelsForRequest(seekerId: string, requestPostId: string): Promise<ChatChannelDTO[]>;
+  getChannel(
+    seekerId: string,
+    requestPostId: string,
+    donorId: string
+  ): Promise<ChatChannelDTO | null>;
+  // Membership: one item per participant; listed by the caller's own user partition.
+  upsertMembership(membership: ChatMembershipDTO): Promise<ChatMembershipDTO>;
+  listMembershipsByUser(userId: string): Promise<ChatMembershipDTO[]>;
+  updateLastRead(userId: string, channelId: string, lastReadAt: string): Promise<void>;
+  // Message: append and read newest-first with a pagination cursor.
+  putMessage(message: ChatMessageDTO): Promise<ChatMessageDTO>;
+  queryMessages(
+    channelId: string,
+    limit?: number,
+    exclusiveStartKey?: Record<string, unknown>
+  ): Promise<ChatHistoryPage>;
+}
+export default ChatRepository

--- a/core/application/models/policies/repositories/ChatRepository.ts
+++ b/core/application/models/policies/repositories/ChatRepository.ts
@@ -22,10 +22,22 @@ type ChatRepository = {
     requestPostId: string,
     donorId: string
   ): Promise<ChatChannelDTO | null>;
+  updateChannelLastMessage(
+    seekerId: string,
+    requestPostId: string,
+    donorId: string,
+    lastMessageAt: string
+  ): Promise<void>;
   // Membership: one item per participant; listed by the caller's own user partition.
   upsertMembership(membership: ChatMembershipDTO): Promise<ChatMembershipDTO>;
   listMembershipsByUser(userId: string): Promise<ChatMembershipDTO[]>;
   updateLastRead(userId: string, channelId: string, lastReadAt: string): Promise<void>;
+  // Bumps the denormalized lastMessageAt so listChannels reflects activity without a channel read.
+  updateMembershipLastMessage(
+    userId: string,
+    channelId: string,
+    lastMessageAt: string
+  ): Promise<void>;
   // Message: append and read newest-first with a pagination cursor.
   putMessage(message: ChatMessageDTO): Promise<ChatMessageDTO>;
   queryMessages(

--- a/core/application/tests/bloodDonationWorkflow/BloodDonationServiceChatLock.test.ts
+++ b/core/application/tests/bloodDonationWorkflow/BloodDonationServiceChatLock.test.ts
@@ -1,0 +1,115 @@
+import { BloodDonationService } from '../../bloodDonationWorkflow/BloodDonationService'
+import { DonationStatus } from '../../../../commons/dto/DonationDTO'
+import { mockLogger } from '../mocks/mockLogger'
+import type { ChatService } from '../../chatWorkflow/ChatService'
+import type { DonationRecordService } from '../../bloodDonationWorkflow/DonationRecordService'
+import type { UserService } from '../../userWorkflow/UserService'
+import type { NotificationService } from '../../notificationWorkflow/NotificationService'
+import type { LocationService } from '../../userWorkflow/LocationService'
+import type { QueueModel } from '../../models/queue/QueueModel'
+
+const donationPost = {
+  seekerId: 'seeker-1',
+  requestPostId: 'req-1',
+  createdAt: '2026-06-26T00:00:00.000Z',
+  requestedBloodGroup: 'O+',
+  bloodQuantity: 2,
+  urgencyLevel: 'urgent',
+  location: 'Dhaka',
+  donationDateTime: '2026-06-30T10:00:00.000Z',
+  status: DonationStatus.PENDING
+}
+
+const buildRepository = () => ({
+  getDonationRequest: jest.fn().mockResolvedValue(donationPost),
+  update: jest.fn().mockResolvedValue(donationPost),
+  create: jest.fn(),
+  query: jest.fn(),
+  getItem: jest.fn(),
+  delete: jest.fn()
+})
+
+const buildChatService = () => ({
+  lockChannel: jest.fn().mockResolvedValue(undefined),
+  lockChannelsForRequest: jest.fn().mockResolvedValue(undefined)
+} as unknown as jest.Mocked<ChatService>)
+
+describe('BloodDonationService chat-channel locking hooks', () => {
+  describe('updateDonationStatus', () => {
+    test.each([DonationStatus.CANCELLED, DonationStatus.EXPIRED])(
+      'locks all of a request\'s channels on %s',
+      async(status) => {
+        const repository = buildRepository()
+        const chatService = buildChatService()
+        const service = new BloodDonationService(repository as never, mockLogger, chatService)
+
+        await service.updateDonationStatus('seeker-1', 'req-1', donationPost.createdAt, status)
+
+        expect(chatService.lockChannelsForRequest).toHaveBeenCalledWith('seeker-1', 'req-1')
+      }
+    )
+
+    test.each([DonationStatus.PENDING, DonationStatus.MANAGED])(
+      'does not lock channels on a non-terminal transition (%s)',
+      async(status) => {
+        const repository = buildRepository()
+        const chatService = buildChatService()
+        const service = new BloodDonationService(repository as never, mockLogger, chatService)
+
+        await service.updateDonationStatus('seeker-1', 'req-1', donationPost.createdAt, status)
+
+        expect(chatService.lockChannelsForRequest).not.toHaveBeenCalled()
+      }
+    )
+
+    test('is a no-op for locking when no chatService is injected', async() => {
+      const repository = buildRepository()
+      const service = new BloodDonationService(repository as never, mockLogger)
+
+      await expect(
+        service.updateDonationStatus('seeker-1', 'req-1', donationPost.createdAt, DonationStatus.CANCELLED)
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('completeDonationRequest', () => {
+    test('locks each donor\'s channel on completion', async() => {
+      const repository = buildRepository()
+      const chatService = buildChatService()
+      const service = new BloodDonationService(repository as never, mockLogger, chatService)
+
+      const donationRecordService = {
+        createDonationRecord: jest.fn().mockResolvedValue(undefined)
+      } as unknown as jest.Mocked<DonationRecordService>
+      const userService = {
+        updateUserAttributes: jest.fn().mockResolvedValue(undefined)
+      } as unknown as jest.Mocked<UserService>
+      const notificationService = {
+        updateBloodDonationNotificationStatus: jest.fn().mockResolvedValue(undefined),
+        sendNotification: jest.fn().mockResolvedValue(undefined)
+      } as unknown as jest.Mocked<NotificationService>
+      const locationService = {} as unknown as jest.Mocked<LocationService>
+      const queueModel = { queue: jest.fn() } as unknown as jest.Mocked<QueueModel>
+
+      await service.completeDonationRequest(
+        'seeker-1',
+        'req-1',
+        donationPost.createdAt,
+        ['donor-1', 'donor-2'],
+        donationRecordService,
+        userService,
+        notificationService,
+        locationService,
+        3,
+        queueModel,
+        'queue-url'
+      )
+
+      expect(chatService.lockChannel).toHaveBeenCalledTimes(2)
+      expect(chatService.lockChannel).toHaveBeenCalledWith('seeker-1', 'req-1', 'donor-1')
+      expect(chatService.lockChannel).toHaveBeenCalledWith('seeker-1', 'req-1', 'donor-2')
+      // Completion locks per-donor, not via the request-wide path.
+      expect(chatService.lockChannelsForRequest).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/core/application/tests/chatWorkflow/ChatService.test.ts
+++ b/core/application/tests/chatWorkflow/ChatService.test.ts
@@ -233,7 +233,7 @@ describe('ChatService', () => {
   })
 
   describe('getHistory', () => {
-    test('passes the limit and cursor through and returns the newest-first page', async() => {
+    test('passes the limit and cursor through and returns the newest-first page with the channel context', async() => {
       const page = {
         items: [
           { channelId: CHANNEL_ID, messageId: 'm2', senderId: SEEKER_ID, content: 'b', createdAt: '2026-06-26T00:00:02.000Z' },
@@ -242,13 +242,26 @@ describe('ChatService', () => {
         lastEvaluatedKey: { PK: 'CHATMSG#x', SK: 'm1' }
       }
       chatRepository.queryMessages.mockResolvedValue(page)
+      chatRepository.getChannel.mockResolvedValue(openChannelDto)
 
       const cursor = { PK: 'CHATMSG#x', SK: 'm3' }
       const result = await chatService.getHistory(CHANNEL_ID, 25, cursor)
 
       expect(chatRepository.queryMessages).toHaveBeenCalledWith(CHANNEL_ID, 25, cursor)
-      expect(result.items[0].messageId).toBe('m2')
-      expect(result.lastEvaluatedKey).toEqual({ PK: 'CHATMSG#x', SK: 'm1' })
+      expect(chatRepository.getChannel).toHaveBeenCalledWith(SEEKER_ID, REQUEST_POST_ID, DONOR_ID)
+      expect(result.page.items[0].messageId).toBe('m2')
+      expect(result.page.lastEvaluatedKey).toEqual({ PK: 'CHATMSG#x', SK: 'm1' })
+      expect(result.channel).toEqual({ status: ChatChannelStatus.OPEN, context })
+    })
+
+    test('returns a null channel when the channel no longer exists', async() => {
+      chatRepository.queryMessages.mockResolvedValue({ items: [] })
+      chatRepository.getChannel.mockResolvedValue(null)
+
+      const result = await chatService.getHistory(CHANNEL_ID)
+
+      expect(result.channel).toBeNull()
+      expect(result.page.items).toEqual([])
     })
   })
 

--- a/core/application/tests/chatWorkflow/ChatService.test.ts
+++ b/core/application/tests/chatWorkflow/ChatService.test.ts
@@ -1,0 +1,277 @@
+import {
+  ChatService,
+  CHAT_RATE_LIMIT,
+  CHAT_RATE_WINDOW_SECONDS
+} from '../../chatWorkflow/ChatService'
+import {
+  ChatChannelStatus,
+  ChatRole,
+  buildChannelId
+} from '../../../../commons/dto/ChatDTO'
+import type {
+  ChatChannelDTO,
+  ChatContextSnapshot,
+  ChatMembershipDTO
+} from '../../../../commons/dto/ChatDTO'
+import ChannelLockedError from '../../chatWorkflow/ChannelLockedError'
+import NotChannelParticipantError from '../../chatWorkflow/NotChannelParticipantError'
+import ChatRateLimitedError from '../../chatWorkflow/ChatRateLimitedError'
+import { generateUniqueID } from '../../utils/idGenerator'
+import { mockLogger } from '../mocks/mockLogger'
+
+jest.mock('../../utils/idGenerator', () => ({
+  generateUniqueID: jest.fn()
+}))
+
+const SEEKER_ID = 'seeker-1'
+const REQUEST_POST_ID = 'req-1'
+const DONOR_ID = 'donor-1'
+const CHANNEL_ID = buildChannelId(SEEKER_ID, REQUEST_POST_ID, DONOR_ID)
+
+const context: ChatContextSnapshot = {
+  requestedBloodGroup: 'O+',
+  urgencyLevel: 'urgent',
+  donationDateTime: '2026-06-30T10:00:00.000Z',
+  location: 'Dhaka'
+}
+
+const openChannelDto: ChatChannelDTO = {
+  channelId: CHANNEL_ID,
+  seekerId: SEEKER_ID,
+  requestPostId: REQUEST_POST_ID,
+  donorId: DONOR_ID,
+  status: ChatChannelStatus.OPEN,
+  context,
+  createdAt: '2026-06-26T00:00:00.000Z'
+}
+
+describe('ChatService', () => {
+  const chatRepository = {
+    upsertChannelOpen: jest.fn(),
+    lockChannel: jest.fn(),
+    listChannelsForRequest: jest.fn(),
+    getChannel: jest.fn(),
+    updateChannelLastMessage: jest.fn(),
+    upsertMembership: jest.fn(),
+    listMembershipsByUser: jest.fn(),
+    updateLastRead: jest.fn(),
+    updateMembershipLastMessage: jest.fn(),
+    putMessage: jest.fn(),
+    queryMessages: jest.fn()
+  }
+
+  const chatRateLimitRepository = {
+    tryConsume: jest.fn()
+  }
+
+  const chatService = new ChatService(chatRepository, chatRateLimitRepository, mockLogger)
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (generateUniqueID as jest.Mock).mockReturnValue('msg-ulid-1')
+    chatRepository.upsertChannelOpen.mockResolvedValue(openChannelDto)
+    chatRepository.upsertMembership.mockImplementation(async(m) => m)
+    chatRepository.putMessage.mockImplementation(async(m) => m)
+    chatRateLimitRepository.tryConsume.mockResolvedValue(true)
+  })
+
+  describe('openChannel', () => {
+    test('opens the channel and upserts both participants\' memberships with the snapshot', async() => {
+      await chatService.openChannel({
+        seekerId: SEEKER_ID,
+        requestPostId: REQUEST_POST_ID,
+        donorId: DONOR_ID,
+        context
+      })
+
+      expect(chatRepository.upsertChannelOpen).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channelId: CHANNEL_ID,
+          status: ChatChannelStatus.OPEN,
+          context
+        })
+      )
+      expect(chatRepository.upsertMembership).toHaveBeenCalledTimes(2)
+      expect(chatRepository.upsertMembership).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: SEEKER_ID, channelId: CHANNEL_ID, role: ChatRole.SEEKER })
+      )
+      expect(chatRepository.upsertMembership).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: DONOR_ID, channelId: CHANNEL_ID, role: ChatRole.DONOR })
+      )
+    })
+
+    test('reopen reuses the same upsert path (creator re-opens a locked channel on re-accept)', async() => {
+      await chatService.openChannel({
+        seekerId: SEEKER_ID,
+        requestPostId: REQUEST_POST_ID,
+        donorId: DONOR_ID,
+        context
+      })
+      await chatService.openChannel({
+        seekerId: SEEKER_ID,
+        requestPostId: REQUEST_POST_ID,
+        donorId: DONOR_ID,
+        context
+      })
+
+      expect(chatRepository.upsertChannelOpen).toHaveBeenCalledTimes(2)
+      expect(chatRepository.upsertMembership).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('sendMessage', () => {
+    test('persists the message and bumps lastMessageAt on the channel and both memberships', async() => {
+      chatRepository.getChannel.mockResolvedValue(openChannelDto)
+
+      const message = await chatService.sendMessage(CHANNEL_ID, SEEKER_ID, 'hello')
+
+      expect(message.messageId).toBe('msg-ulid-1')
+      expect(chatRepository.putMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ channelId: CHANNEL_ID, senderId: SEEKER_ID, content: 'hello' })
+      )
+      expect(chatRepository.updateChannelLastMessage).toHaveBeenCalledWith(
+        SEEKER_ID,
+        REQUEST_POST_ID,
+        DONOR_ID,
+        expect.any(String)
+      )
+      expect(chatRepository.updateMembershipLastMessage).toHaveBeenCalledWith(
+        SEEKER_ID,
+        CHANNEL_ID,
+        expect.any(String)
+      )
+      expect(chatRepository.updateMembershipLastMessage).toHaveBeenCalledWith(
+        DONOR_ID,
+        CHANNEL_ID,
+        expect.any(String)
+      )
+    })
+
+    test('rejects a non-participant before touching the channel', async() => {
+      await expect(
+        chatService.sendMessage(CHANNEL_ID, 'intruder', 'hi')
+      ).rejects.toBeInstanceOf(NotChannelParticipantError)
+
+      expect(chatRepository.getChannel).not.toHaveBeenCalled()
+      expect(chatRepository.putMessage).not.toHaveBeenCalled()
+    })
+
+    test('rejects sending to a LOCKED channel', async() => {
+      chatRepository.getChannel.mockResolvedValue({
+        ...openChannelDto,
+        status: ChatChannelStatus.LOCKED
+      })
+
+      await expect(
+        chatService.sendMessage(CHANNEL_ID, DONOR_ID, 'hi')
+      ).rejects.toBeInstanceOf(ChannelLockedError)
+
+      expect(chatRepository.putMessage).not.toHaveBeenCalled()
+    })
+
+    test('rejects sending to a channel that does not exist', async() => {
+      chatRepository.getChannel.mockResolvedValue(null)
+
+      await expect(
+        chatService.sendMessage(CHANNEL_ID, DONOR_ID, 'hi')
+      ).rejects.toBeInstanceOf(ChannelLockedError)
+    })
+
+    test('rejects the message when the rate limiter denies it', async() => {
+      chatRepository.getChannel.mockResolvedValue(openChannelDto)
+      chatRateLimitRepository.tryConsume.mockResolvedValue(false)
+
+      await expect(
+        chatService.sendMessage(CHANNEL_ID, SEEKER_ID, 'hi')
+      ).rejects.toBeInstanceOf(ChatRateLimitedError)
+
+      expect(chatRateLimitRepository.tryConsume).toHaveBeenCalledWith(
+        CHANNEL_ID,
+        CHAT_RATE_LIMIT,
+        CHAT_RATE_WINDOW_SECONDS
+      )
+      expect(chatRepository.putMessage).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('listChannels', () => {
+    test('returns the caller\'s memberships whether they act as seeker or donor', async() => {
+      const asSeeker: ChatMembershipDTO = {
+        userId: 'user-x',
+        channelId: buildChannelId('user-x', 'req-a', 'donor-9'),
+        role: ChatRole.SEEKER,
+        lastReadAt: '2026-06-26T01:00:00.000Z',
+        lastMessageAt: '2026-06-26T02:00:00.000Z',
+        createdAt: '2026-06-26T00:00:00.000Z'
+      }
+      const asDonor: ChatMembershipDTO = {
+        userId: 'user-x',
+        channelId: buildChannelId('seeker-9', 'req-b', 'user-x'),
+        role: ChatRole.DONOR,
+        createdAt: '2026-06-26T00:00:00.000Z'
+      }
+      chatRepository.listMembershipsByUser.mockResolvedValue([asSeeker, asDonor])
+
+      const channels = await chatService.listChannels('user-x')
+
+      expect(chatRepository.listMembershipsByUser).toHaveBeenCalledWith('user-x')
+      expect(channels.map((c) => c.role)).toEqual([ChatRole.SEEKER, ChatRole.DONOR])
+    })
+  })
+
+  describe('markRead', () => {
+    test('updates only the caller\'s membership marker', async() => {
+      await chatService.markRead(DONOR_ID, CHANNEL_ID)
+
+      expect(chatRepository.updateLastRead).toHaveBeenCalledTimes(1)
+      expect(chatRepository.updateLastRead).toHaveBeenCalledWith(
+        DONOR_ID,
+        CHANNEL_ID,
+        expect.any(String)
+      )
+    })
+  })
+
+  describe('getHistory', () => {
+    test('passes the limit and cursor through and returns the newest-first page', async() => {
+      const page = {
+        items: [
+          { channelId: CHANNEL_ID, messageId: 'm2', senderId: SEEKER_ID, content: 'b', createdAt: '2026-06-26T00:00:02.000Z' },
+          { channelId: CHANNEL_ID, messageId: 'm1', senderId: DONOR_ID, content: 'a', createdAt: '2026-06-26T00:00:01.000Z' }
+        ],
+        lastEvaluatedKey: { PK: 'CHATMSG#x', SK: 'm1' }
+      }
+      chatRepository.queryMessages.mockResolvedValue(page)
+
+      const cursor = { PK: 'CHATMSG#x', SK: 'm3' }
+      const result = await chatService.getHistory(CHANNEL_ID, 25, cursor)
+
+      expect(chatRepository.queryMessages).toHaveBeenCalledWith(CHANNEL_ID, 25, cursor)
+      expect(result.items[0].messageId).toBe('m2')
+      expect(result.lastEvaluatedKey).toEqual({ PK: 'CHATMSG#x', SK: 'm1' })
+    })
+  })
+
+  describe('lockChannel', () => {
+    test('locks a single channel by its participants', async() => {
+      await chatService.lockChannel(SEEKER_ID, REQUEST_POST_ID, DONOR_ID)
+
+      expect(chatRepository.lockChannel).toHaveBeenCalledWith(SEEKER_ID, REQUEST_POST_ID, DONOR_ID)
+    })
+  })
+
+  describe('lockChannelsForRequest', () => {
+    test('locks every channel of a request', async() => {
+      chatRepository.listChannelsForRequest.mockResolvedValue([
+        { ...openChannelDto, donorId: 'donor-1' },
+        { ...openChannelDto, donorId: 'donor-2' }
+      ])
+
+      await chatService.lockChannelsForRequest(SEEKER_ID, REQUEST_POST_ID)
+
+      expect(chatRepository.lockChannel).toHaveBeenCalledTimes(2)
+      expect(chatRepository.lockChannel).toHaveBeenCalledWith(SEEKER_ID, REQUEST_POST_ID, 'donor-1')
+      expect(chatRepository.lockChannel).toHaveBeenCalledWith(SEEKER_ID, REQUEST_POST_ID, 'donor-2')
+    })
+  })
+})

--- a/core/services/aws/bloodDonation/cancelBloodDonation.ts
+++ b/core/services/aws/bloodDonation/cancelBloodDonation.ts
@@ -12,6 +12,9 @@ import type { HttpLoggerAttributes } from '../commons/logger/HttpLogger'
 import { createHTTPLogger } from '../commons/logger/HttpLogger'
 import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
 import { Config } from '../../../../commons/libs/config/config'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
 
 const config = new Config<{
   dynamodbTableName: string;
@@ -19,6 +22,14 @@ const config = new Config<{
 }>().getConfig()
 
 const bloodDonationDynamoDbOperations = new BloodDonationDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatDynamoDbOperations = new ChatDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
   config.dynamodbTableName,
   config.awsRegion
 )
@@ -31,7 +42,16 @@ async function cancelBloodDonation(
     event.apiGwRequestId,
     event.cloudFrontRequestId
   )
-  const bloodDonationService = new BloodDonationService(bloodDonationDynamoDbOperations, httpLogger)
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    httpLogger
+  )
+  const bloodDonationService = new BloodDonationService(
+    bloodDonationDynamoDbOperations,
+    httpLogger,
+    chatService
+  )
   try {
     await bloodDonationService.updateDonationStatus(
       event.seekerId,

--- a/core/services/aws/bloodDonation/completeDonationRequest.ts
+++ b/core/services/aws/bloodDonation/completeDonationRequest.ts
@@ -20,6 +20,9 @@ import DonationNotificationDynamoDbOperations from '../commons/ddbOperations/Don
 import UserDynamoDbOperations from '../commons/ddbOperations/UserDynamoDbOperations'
 import { LocationService } from 'core/application/userWorkflow/LocationService'
 import SQSOperations from '../commons/sqs/SQSOperations'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
 
 const config = new Config<{
   dynamodbTableName: string;
@@ -48,6 +51,14 @@ const locationDynamoDbOperations = new LocationDynamoDbOperations(
   config.dynamodbTableName,
   config.awsRegion
 )
+const chatDynamoDbOperations = new ChatDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
 
 
 async function completeDonationRequest(
@@ -58,7 +69,16 @@ async function completeDonationRequest(
     event.apiGwRequestId,
     event.cloudFrontRequestId
   )
-  const bloodDonationService = new BloodDonationService(bloodDonationDynamoDbOperations, httpLogger)
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    httpLogger
+  )
+  const bloodDonationService = new BloodDonationService(
+    bloodDonationDynamoDbOperations,
+    httpLogger,
+    chatService
+  )
   const notificationService = new NotificationService(notificationDynamoDbOperations, httpLogger)
   const userService = new UserService(userDynamoDbOperations, httpLogger)
   const donationRecordService = new DonationRecordService(donationRecordDynamoDbOperations, httpLogger)

--- a/core/services/aws/chat/chatChannelCreator.ts
+++ b/core/services/aws/chat/chatChannelCreator.ts
@@ -1,0 +1,88 @@
+import { BloodDonationService } from '../../../application/bloodDonationWorkflow/BloodDonationService'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import BloodDonationDynamoDbOperations from '../commons/ddbOperations/BloodDonationDynamoDbOperations'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const bloodDonationDynamoDbOperations = new BloodDonationDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatDynamoDbOperations = new ChatDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+// EventBridge pipe payload (INSERT of an ACCEPTED# record): PK=BLOOD_REQ#<seekerId>,
+// SK=ACCEPTED#<requestPostId>#<donorId>, createdAt is the donation post's createdAt.
+type ChannelCreateEvent = {
+  PK: string;
+  SK: string;
+  createdAt: string;
+}
+
+async function chatChannelCreator(
+  event: ChannelCreateEvent | ChannelCreateEvent[]
+): Promise<{ status: string }> {
+  try {
+    const events = Array.isArray(event) ? event : [event]
+    for (const body of events) {
+      await processChannelCreateEvent(body)
+    }
+
+    return { status: 'Success' }
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(UNKNOWN_ERROR_MESSAGE)
+  }
+}
+
+async function processChannelCreateEvent(body: ChannelCreateEvent): Promise<void> {
+  if (body.PK === '' || body.SK === '') {
+    throw new Error('Missing PK or SK in the DynamoDB record')
+  }
+
+  const seekerId = body.PK.split('#')[1]
+  const [, requestPostId, donorId] = body.SK.split('#')
+
+  const logger = createServiceLogger(seekerId, { requestPostId, donorId, createdAt: body.createdAt })
+  const bloodDonationService = new BloodDonationService(bloodDonationDynamoDbOperations, logger)
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    logger
+  )
+
+  // Read the donation post to snapshot the request context onto the channel, so the chat header
+  // renders on a cold-start deep-link without a separate post fetch.
+  const donationPost = await bloodDonationService.getDonationRequest(
+    seekerId,
+    requestPostId,
+    body.createdAt
+  )
+
+  await chatService.openChannel({
+    seekerId,
+    requestPostId,
+    donorId,
+    context: {
+      requestedBloodGroup: donationPost.requestedBloodGroup,
+      urgencyLevel: donationPost.urgencyLevel,
+      donationDateTime: donationPost.donationDateTime,
+      location: donationPost.location
+    }
+  })
+}
+
+export default chatChannelCreator

--- a/core/services/aws/chat/chatChannelLocker.ts
+++ b/core/services/aws/chat/chatChannelLocker.ts
@@ -1,0 +1,65 @@
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatDynamoDbOperations = new ChatDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+// EventBridge pipe payload (REMOVE of an ACCEPTED# record = IGNORED): PK=BLOOD_REQ#<seekerId>,
+// SK=ACCEPTED#<requestPostId>#<donorId>.
+type ChannelLockEvent = {
+  PK: string;
+  SK: string;
+  createdAt: string;
+}
+
+async function chatChannelLocker(
+  event: ChannelLockEvent | ChannelLockEvent[]
+): Promise<{ status: string }> {
+  try {
+    const events = Array.isArray(event) ? event : [event]
+    for (const body of events) {
+      await processChannelLockEvent(body)
+    }
+
+    return { status: 'Success' }
+  } catch (error) {
+    throw error instanceof Error ? error : new Error(UNKNOWN_ERROR_MESSAGE)
+  }
+}
+
+async function processChannelLockEvent(body: ChannelLockEvent): Promise<void> {
+  if (body.PK === '' || body.SK === '') {
+    throw new Error('Missing PK or SK in the DynamoDB record')
+  }
+
+  const seekerId = body.PK.split('#')[1]
+  const [, requestPostId, donorId] = body.SK.split('#')
+
+  const logger = createServiceLogger(seekerId, { requestPostId, donorId })
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    logger
+  )
+
+  // Conditional lock; a no-op if the channel was never created (the adapter swallows the
+  // attribute_exists check failure), so an ignore of an unchatted donor leaves no phantom record.
+  await chatService.lockChannel(seekerId, requestPostId, donorId)
+}
+
+export default chatChannelLocker

--- a/core/services/aws/chat/chatConnect.ts
+++ b/core/services/aws/chat/chatConnect.ts
@@ -1,0 +1,44 @@
+import ChatConnectionDynamoDbOperations from '../commons/ddbOperations/ChatConnectionDynamoDbOperations'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatConnectionOperations = new ChatConnectionDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+// WebSocket $connect: the request authorizer has already validated the JWT and put the userId in
+// the authorizer context; store the connection keyed by connectionId (with userId on GSI1 for fanout).
+type ConnectEvent = {
+  requestContext: {
+    connectionId: string;
+    authorizer?: { userId?: string };
+  };
+}
+
+async function chatConnect(event: ConnectEvent): Promise<{ statusCode: number }> {
+  const { connectionId, authorizer } = event.requestContext
+  const userId = authorizer?.userId
+  const logger = createServiceLogger(userId ?? 'unknown', { connectionId })
+
+  if (userId === undefined || userId === '') {
+    logger.error('missing userId in authorizer context')
+
+    return { statusCode: 401 }
+  }
+
+  await chatConnectionOperations.put({
+    connectionId,
+    userId,
+    createdAt: new Date().toISOString()
+  })
+
+  return { statusCode: 200 }
+}
+
+export default chatConnect

--- a/core/services/aws/chat/chatConnectAuthorizer.ts
+++ b/core/services/aws/chat/chatConnectAuthorizer.ts
@@ -1,0 +1,70 @@
+import { CognitoJwtVerifier } from 'aws-jwt-verify'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  cognitoUserPoolId: string;
+  cognitoClientId: string;
+}>().getConfig()
+
+// Created once per container so the JWKS is fetched and cached across invocations.
+// tokenUse 'access': the WebSocket client (Phase 6) sends the Cognito access token as ?token=.
+const jwtVerifier = CognitoJwtVerifier.create({
+  userPoolId: config.cognitoUserPoolId,
+  tokenUse: 'access',
+  clientId: config.cognitoClientId
+})
+
+type AuthorizerEvent = {
+  methodArn: string;
+  queryStringParameters?: Record<string, string | undefined> | null;
+}
+
+type AuthorizerResult = {
+  principalId: string;
+  policyDocument: {
+    Version: string;
+    Statement: { Action: string; Effect: 'Allow' | 'Deny'; Resource: string }[];
+  };
+  context?: { userId: string };
+}
+
+const buildPolicy = (
+  principalId: string,
+  effect: 'Allow' | 'Deny',
+  resource: string,
+  context?: { userId: string }
+): AuthorizerResult => ({
+  principalId,
+  policyDocument: {
+    Version: '2012-10-17',
+    Statement: [{ Action: 'execute-api:Invoke', Effect: effect, Resource: resource }]
+  },
+  ...(context !== undefined ? { context } : {})
+})
+
+// WebSocket $connect REQUEST authorizer: validates the Cognito JWT carried as the `token` query
+// param and passes the userId to the connect handler via the authorizer context. An invalid token
+// yields a Deny policy (403), never an allow.
+async function chatConnectAuthorizer(event: AuthorizerEvent): Promise<AuthorizerResult> {
+  const token = event.queryStringParameters?.token
+  const logger = createServiceLogger('chat-authorizer')
+
+  if (token === undefined || token === '') {
+    logger.error('missing token query parameter')
+
+    return buildPolicy('unauthorized', 'Deny', event.methodArn)
+  }
+
+  try {
+    const payload = await jwtVerifier.verify(token)
+
+    return buildPolicy(payload.sub, 'Allow', event.methodArn, { userId: payload.sub })
+  } catch (error) {
+    logger.error({ error }, 'token verification failed')
+
+    return buildPolicy('unauthorized', 'Deny', event.methodArn)
+  }
+}
+
+export default chatConnectAuthorizer

--- a/core/services/aws/chat/chatDisconnect.ts
+++ b/core/services/aws/chat/chatDisconnect.ts
@@ -1,0 +1,33 @@
+import ChatConnectionDynamoDbOperations from '../commons/ddbOperations/ChatConnectionDynamoDbOperations'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatConnectionOperations = new ChatConnectionDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+// WebSocket $disconnect carries only the connectionId (no authorizer re-run), so the connection
+// item is keyed and deleted by connectionId alone.
+type DisconnectEvent = {
+  requestContext: {
+    connectionId: string;
+  };
+}
+
+async function chatDisconnect(event: DisconnectEvent): Promise<{ statusCode: number }> {
+  const { connectionId } = event.requestContext
+  const logger = createServiceLogger(connectionId, { connectionId })
+
+  await chatConnectionOperations.deleteByConnectionId(connectionId)
+  logger.info('connection removed')
+
+  return { statusCode: 200 }
+}
+
+export default chatDisconnect

--- a/core/services/aws/chat/chatGetHistory.ts
+++ b/core/services/aws/chat/chatGetHistory.ts
@@ -42,9 +42,9 @@ async function chatGetHistory(event: GetHistoryEvent): Promise<APIGatewayProxyRe
   )
 
   try {
-    const page = await chatService.getHistory(event.channelId, event.limit, event.exclusiveStartKey)
+    const result = await chatService.getHistory(event.channelId, event.limit, event.exclusiveStartKey)
 
-    return generateApiGatewayResponse({ success: true, data: page }, HTTP_CODES.OK)
+    return generateApiGatewayResponse({ success: true, data: result }, HTTP_CODES.OK)
   } catch (error) {
     httpLogger.error(error)
     const errorMessage = error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE

--- a/core/services/aws/chat/chatGetHistory.ts
+++ b/core/services/aws/chat/chatGetHistory.ts
@@ -1,0 +1,56 @@
+import type { APIGatewayProxyResult } from 'aws-lambda'
+import { HTTP_CODES } from '../../../../commons/libs/constants/GenericCodes'
+import generateApiGatewayResponse from '../commons/lambda/ApiGateway'
+import { isChannelParticipant } from '../../../../commons/dto/ChatDTO'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import type { HttpLoggerAttributes } from '../commons/logger/HttpLogger'
+import { createHTTPLogger } from '../commons/logger/HttpLogger'
+import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
+import { Config } from '../../../../commons/libs/config/config'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatDynamoDbOperations = new ChatDynamoDbOperations(config.dynamodbTableName, config.awsRegion)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+type GetHistoryEvent = HttpLoggerAttributes & {
+  channelId: string;
+  limit?: number;
+  exclusiveStartKey?: Record<string, unknown>;
+}
+
+// Returns a newest-first, paginated page of a channel's messages; participant-only.
+async function chatGetHistory(event: GetHistoryEvent): Promise<APIGatewayProxyResult> {
+  const httpLogger = createHTTPLogger(event.userId, event.apiGwRequestId, event.cloudFrontRequestId)
+
+  if (!isChannelParticipant(event.userId, event.channelId)) {
+    return generateApiGatewayResponse('Error: Not a participant of this channel.', HTTP_CODES.UNAUTHORIZED)
+  }
+
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    httpLogger
+  )
+
+  try {
+    const page = await chatService.getHistory(event.channelId, event.limit, event.exclusiveStartKey)
+
+    return generateApiGatewayResponse({ success: true, data: page }, HTTP_CODES.OK)
+  } catch (error) {
+    httpLogger.error(error)
+    const errorMessage = error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE
+
+    return generateApiGatewayResponse(`Error: ${errorMessage}`, HTTP_CODES.ERROR)
+  }
+}
+
+export default chatGetHistory

--- a/core/services/aws/chat/chatListChannels.ts
+++ b/core/services/aws/chat/chatListChannels.ts
@@ -1,0 +1,47 @@
+import type { APIGatewayProxyResult } from 'aws-lambda'
+import { HTTP_CODES } from '../../../../commons/libs/constants/GenericCodes'
+import generateApiGatewayResponse from '../commons/lambda/ApiGateway'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import type { HttpLoggerAttributes } from '../commons/logger/HttpLogger'
+import { createHTTPLogger } from '../commons/logger/HttpLogger'
+import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
+import { Config } from '../../../../commons/libs/config/config'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatDynamoDbOperations = new ChatDynamoDbOperations(config.dynamodbTableName, config.awsRegion)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+// Lists the caller's own chat channels (their membership items), each carrying lastMessageAt and
+// the caller's lastReadAt so the client derives the unread indicator.
+async function chatListChannels(
+  event: HttpLoggerAttributes
+): Promise<APIGatewayProxyResult> {
+  const httpLogger = createHTTPLogger(event.userId, event.apiGwRequestId, event.cloudFrontRequestId)
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    httpLogger
+  )
+
+  try {
+    const channels = await chatService.listChannels(event.userId)
+
+    return generateApiGatewayResponse({ success: true, data: channels }, HTTP_CODES.OK)
+  } catch (error) {
+    httpLogger.error(error)
+    const errorMessage = error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE
+
+    return generateApiGatewayResponse(`Error: ${errorMessage}`, HTTP_CODES.ERROR)
+  }
+}
+
+export default chatListChannels

--- a/core/services/aws/chat/chatMarkRead.ts
+++ b/core/services/aws/chat/chatMarkRead.ts
@@ -1,0 +1,54 @@
+import type { APIGatewayProxyResult } from 'aws-lambda'
+import { HTTP_CODES } from '../../../../commons/libs/constants/GenericCodes'
+import generateApiGatewayResponse from '../commons/lambda/ApiGateway'
+import { isChannelParticipant } from '../../../../commons/dto/ChatDTO'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import type { HttpLoggerAttributes } from '../commons/logger/HttpLogger'
+import { createHTTPLogger } from '../commons/logger/HttpLogger'
+import { UNKNOWN_ERROR_MESSAGE } from '../../../../commons/libs/constants/ApiResponseMessages'
+import { Config } from '../../../../commons/libs/config/config'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+}>().getConfig()
+
+const chatDynamoDbOperations = new ChatDynamoDbOperations(config.dynamodbTableName, config.awsRegion)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+type MarkReadEvent = HttpLoggerAttributes & {
+  channelId: string;
+}
+
+// Updates the caller's own lastReadAt marker on the channel (participant-only); not a read receipt.
+async function chatMarkRead(event: MarkReadEvent): Promise<APIGatewayProxyResult> {
+  const httpLogger = createHTTPLogger(event.userId, event.apiGwRequestId, event.cloudFrontRequestId)
+
+  if (!isChannelParticipant(event.userId, event.channelId)) {
+    return generateApiGatewayResponse('Error: Not a participant of this channel.', HTTP_CODES.UNAUTHORIZED)
+  }
+
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    httpLogger
+  )
+
+  try {
+    await chatService.markRead(event.userId, event.channelId)
+
+    return generateApiGatewayResponse({ success: true, message: 'Marked as read.' }, HTTP_CODES.OK)
+  } catch (error) {
+    httpLogger.error(error)
+    const errorMessage = error instanceof Error ? error.message : UNKNOWN_ERROR_MESSAGE
+
+    return generateApiGatewayResponse(`Error: ${errorMessage}`, HTTP_CODES.ERROR)
+  }
+}
+
+export default chatMarkRead

--- a/core/services/aws/chat/chatSendMessage.ts
+++ b/core/services/aws/chat/chatSendMessage.ts
@@ -1,0 +1,154 @@
+import { parseChannelId } from '../../../../commons/dto/ChatDTO'
+import type { ChatMessageDTO } from '../../../../commons/dto/ChatDTO'
+import { NotificationType } from '../../../../commons/dto/NotificationDTO'
+import type { NotificationAttributes } from '../../../application/notificationWorkflow/Types'
+import { ChatService } from '../../../application/chatWorkflow/ChatService'
+import type { QueueModel } from '../../../application/models/queue/QueueModel'
+import ApplicationError from '../../../../commons/libs/errors/ApplicationError'
+import ChatDynamoDbOperations from '../commons/ddbOperations/ChatDynamoDbOperations'
+import ChatRateLimitDynamoDbOperations from '../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import ChatConnectionDynamoDbOperations from '../commons/ddbOperations/ChatConnectionDynamoDbOperations'
+import WebSocketOperations from '../commons/apiGateway/WebSocketOperations'
+import SQSOperations from '../commons/sqs/SQSOperations'
+import { Config } from '../../../../commons/libs/config/config'
+import { createServiceLogger } from '../commons/logger/ServiceLogger'
+
+const config = new Config<{
+  dynamodbTableName: string;
+  awsRegion: string;
+  notificationQueueUrl: string;
+}>().getConfig()
+
+const chatDynamoDbOperations = new ChatDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatRateLimitDynamoDbOperations = new ChatRateLimitDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+const chatConnectionDynamoDbOperations = new ChatConnectionDynamoDbOperations(
+  config.dynamodbTableName,
+  config.awsRegion
+)
+
+type SendMessageEvent = {
+  requestContext: {
+    connectionId: string;
+    domainName: string;
+    stage: string;
+  };
+  body?: string | null;
+}
+
+const parseBody = (body?: string | null): { channelId: string; content: string } | null => {
+  if (body === undefined || body === null || body === '') {
+    return null
+  }
+  try {
+    const parsed = JSON.parse(body)
+    if (
+      typeof parsed.channelId === 'string'
+      && typeof parsed.content === 'string'
+      && parsed.content !== ''
+    ) {
+      return { channelId: parsed.channelId, content: parsed.content }
+    }
+
+    return null
+  } catch {
+    return null
+  }
+}
+
+const enqueueChatPush = async(
+  queueModel: QueueModel,
+  recipientId: string,
+  message: ChatMessageDTO
+): Promise<void> => {
+  const notification: NotificationAttributes = {
+    userId: recipientId,
+    title: 'New message',
+    body: 'You have a new chat message.',
+    type: NotificationType.CHAT_MESSAGE,
+    payload: {
+      channelId: message.channelId,
+      senderId: message.senderId,
+      messageId: message.messageId,
+      createdAt: message.createdAt
+    }
+  }
+  await queueModel.queue(notification, config.notificationQueueUrl)
+}
+
+// WebSocket sendMessage: resolves the sender from the connection store (the $connect authorizer
+// context is not propagated to message routes), persists via ChatService (which enforces
+// participant-only + not-locked + rate limit), fans the saved message out to both participants'
+// live connections, prunes stale connections, and enqueues an offline push for a recipient with no
+// live connection.
+async function chatSendMessage(event: SendMessageEvent): Promise<{ statusCode: number }> {
+  const { connectionId, domainName, stage } = event.requestContext
+  const logger = createServiceLogger('chat-send-message', { connectionId })
+
+  const senderConnection = await chatConnectionDynamoDbOperations.getByConnectionId(connectionId)
+  if (senderConnection === null) {
+    logger.error('no stored connection for sender')
+
+    return { statusCode: 401 }
+  }
+  const senderId = senderConnection.userId
+
+  const parsed = parseBody(event.body)
+  if (parsed === null) {
+    return { statusCode: 400 }
+  }
+  const { channelId, content } = parsed
+
+  const chatService = new ChatService(
+    chatDynamoDbOperations,
+    chatRateLimitDynamoDbOperations,
+    logger
+  )
+
+  let savedMessage: ChatMessageDTO
+  try {
+    savedMessage = await chatService.sendMessage(channelId, senderId, content)
+  } catch (error) {
+    logger.error({ error }, 'sendMessage rejected')
+
+    return { statusCode: error instanceof ApplicationError ? error.errorCode : 500 }
+  }
+
+  const webSocketOperations = new WebSocketOperations(
+    `https://${domainName}/${stage}`,
+    config.awsRegion
+  )
+  const queueModel = new SQSOperations(config.awsRegion)
+  const { seekerId, donorId } = parseChannelId(channelId)
+
+  for (const participantId of [seekerId, donorId]) {
+    const connections = await chatConnectionDynamoDbOperations.queryByUserId(participantId)
+
+    if (connections.length === 0) {
+      // Offline recipient (never the sender) gets a push fallback.
+      if (participantId !== senderId) {
+        await enqueueChatPush(queueModel, participantId, savedMessage)
+      }
+      continue
+    }
+
+    for (const connection of connections) {
+      const { gone } = await webSocketOperations.postToConnection(
+        connection.connectionId,
+        savedMessage
+      )
+      if (gone) {
+        await chatConnectionDynamoDbOperations.deleteByConnectionId(connection.connectionId)
+      }
+    }
+  }
+
+  return { statusCode: 200 }
+}
+
+export default chatSendMessage

--- a/core/services/aws/commons/apiGateway/WebSocketOperations.ts
+++ b/core/services/aws/commons/apiGateway/WebSocketOperations.ts
@@ -1,0 +1,34 @@
+import {
+  ApiGatewayManagementApiClient,
+  PostToConnectionCommand,
+  GoneException
+} from '@aws-sdk/client-apigatewaymanagementapi'
+
+// Thin wrapper over the API Gateway Management API used to push messages back to live WebSocket
+// connections. The endpoint is derived per-invocation from the WebSocket event's requestContext
+// (`https://<domainName>/<stage>`).
+export default class WebSocketOperations {
+  private readonly client: ApiGatewayManagementApiClient
+
+  constructor(endpoint: string, region: string) {
+    this.client = new ApiGatewayManagementApiClient({ endpoint, region })
+  }
+
+  // Posts data to a connection. Returns { gone: true } when the connection is stale (410), so the
+  // caller can prune it; other errors propagate.
+  async postToConnection(connectionId: string, data: unknown): Promise<{ gone: boolean }> {
+    try {
+      await this.client.send(new PostToConnectionCommand({
+        ConnectionId: connectionId,
+        Data: Buffer.from(JSON.stringify(data))
+      }))
+
+      return { gone: false }
+    } catch (error) {
+      if (error instanceof GoneException) {
+        return { gone: true }
+      }
+      throw error
+    }
+  }
+}

--- a/core/services/aws/commons/ddbModels/ChatChannelModel.ts
+++ b/core/services/aws/commons/ddbModels/ChatChannelModel.ts
@@ -1,0 +1,75 @@
+import type { ChatChannelDTO } from '../../../../../commons/dto/ChatDTO'
+import type {
+  DbModelDtoAdapter,
+  HasTimeLog,
+  NosqlModel,
+  DbIndex,
+  IndexDefinitions,
+  IndexType
+} from './DbModelDefinitions'
+
+export const CHAT_CHANNEL_PK_PREFIX = 'CHANNEL'
+export const CHAT_CHANNEL_SK_PREFIX = 'DONOR'
+
+// channelId is the composite identity carried on membership and message items.
+export const buildChannelId = (seekerId: string, requestPostId: string, donorId: string): string =>
+  `${seekerId}#${requestPostId}#${donorId}`
+
+export const parseChannelId = (
+  channelId: string
+): { seekerId: string; requestPostId: string; donorId: string } => {
+  const [seekerId, requestPostId, donorId] = channelId.split('#')
+
+  return { seekerId, requestPostId, donorId }
+}
+
+export type ChatChannelFields = Omit<
+ChatChannelDTO,
+'channelId' | 'seekerId' | 'requestPostId' | 'donorId'
+> &
+HasTimeLog & {
+  PK: `${typeof CHAT_CHANNEL_PK_PREFIX}#${string}#${string}`;
+  SK: `${typeof CHAT_CHANNEL_SK_PREFIX}#${string}`;
+}
+
+export class ChatChannelModel
+implements
+    NosqlModel<ChatChannelFields>,
+    DbModelDtoAdapter<ChatChannelDTO, ChatChannelFields> {
+  getIndexDefinitions(): IndexDefinitions<ChatChannelFields> {
+    return {}
+  }
+
+  getPrimaryIndex(): DbIndex<ChatChannelFields> {
+    return { partitionKey: 'PK', sortKey: 'SK' }
+  }
+
+  getIndex(indexType: IndexType, indexName: string): DbIndex<ChatChannelFields> | undefined {
+    return this.getIndexDefinitions()[indexType]?.[indexName]
+  }
+
+  fromDto(channelDto: ChatChannelDTO): ChatChannelFields {
+    const { channelId, seekerId, requestPostId, donorId, ...remainingData } = channelDto
+
+    return {
+      PK: `${CHAT_CHANNEL_PK_PREFIX}#${seekerId}#${requestPostId}`,
+      SK: `${CHAT_CHANNEL_SK_PREFIX}#${donorId}`,
+      ...remainingData
+    }
+  }
+
+  toDto(dbFields: ChatChannelFields): ChatChannelDTO {
+    const { PK, SK, ...remainingFields } = dbFields
+    const seekerId = PK.replace(`${CHAT_CHANNEL_PK_PREFIX}#`, '').split('#')[0]
+    const requestPostId = PK.replace(`${CHAT_CHANNEL_PK_PREFIX}#`, '').split('#')[1]
+    const donorId = SK.replace(`${CHAT_CHANNEL_SK_PREFIX}#`, '')
+
+    return {
+      ...remainingFields,
+      channelId: buildChannelId(seekerId, requestPostId, donorId),
+      seekerId,
+      requestPostId,
+      donorId
+    }
+  }
+}

--- a/core/services/aws/commons/ddbModels/ChatChannelModel.ts
+++ b/core/services/aws/commons/ddbModels/ChatChannelModel.ts
@@ -1,4 +1,8 @@
 import type { ChatChannelDTO } from '../../../../../commons/dto/ChatDTO'
+// channelId helpers are the single source of truth in commons/dto/ChatDTO (shared with the
+// application layer); imported for use in toDto and re-exported so existing model/test imports
+// keep working.
+import { buildChannelId, parseChannelId } from '../../../../../commons/dto/ChatDTO'
 import type {
   DbModelDtoAdapter,
   HasTimeLog,
@@ -8,20 +12,10 @@ import type {
   IndexType
 } from './DbModelDefinitions'
 
+export { buildChannelId, parseChannelId }
+
 export const CHAT_CHANNEL_PK_PREFIX = 'CHANNEL'
 export const CHAT_CHANNEL_SK_PREFIX = 'DONOR'
-
-// channelId is the composite identity carried on membership and message items.
-export const buildChannelId = (seekerId: string, requestPostId: string, donorId: string): string =>
-  `${seekerId}#${requestPostId}#${donorId}`
-
-export const parseChannelId = (
-  channelId: string
-): { seekerId: string; requestPostId: string; donorId: string } => {
-  const [seekerId, requestPostId, donorId] = channelId.split('#')
-
-  return { seekerId, requestPostId, donorId }
-}
 
 export type ChatChannelFields = Omit<
 ChatChannelDTO,

--- a/core/services/aws/commons/ddbModels/ChatConnectionModel.ts
+++ b/core/services/aws/commons/ddbModels/ChatConnectionModel.ts
@@ -1,0 +1,68 @@
+import type { ChatConnectionDTO } from '../../../../../commons/dto/ChatDTO'
+import type {
+  DbModelDtoAdapter,
+  HasTimeLog,
+  NosqlModel,
+  DbIndex,
+  IndexDefinitions,
+  IndexType
+} from './DbModelDefinitions'
+
+export const CHAT_CONNECTION_PK_PREFIX = 'CONNECTION'
+export const CHAT_CONNECTION_GSI1PK_PREFIX = 'CHATUSER'
+
+// Keyed by connectionId (the only key $disconnect carries); GSI1 on userId lists a
+// user's live connections for fanout.
+export type ChatConnectionFields = Omit<ChatConnectionDTO, 'connectionId' | 'userId'> &
+HasTimeLog & {
+  PK: `${typeof CHAT_CONNECTION_PK_PREFIX}#${string}`;
+  SK: `${typeof CHAT_CONNECTION_PK_PREFIX}#${string}`;
+  GSI1PK: `${typeof CHAT_CONNECTION_GSI1PK_PREFIX}#${string}`;
+  GSI1SK: `${typeof CHAT_CONNECTION_PK_PREFIX}#${string}`;
+}
+
+export class ChatConnectionModel
+implements
+    NosqlModel<ChatConnectionFields>,
+    DbModelDtoAdapter<ChatConnectionDTO, ChatConnectionFields> {
+  getIndexDefinitions(): IndexDefinitions<ChatConnectionFields> {
+    return {
+      GSI: {
+        GSI1: {
+          partitionKey: 'GSI1PK',
+          sortKey: 'GSI1SK'
+        }
+      }
+    }
+  }
+
+  getPrimaryIndex(): DbIndex<ChatConnectionFields> {
+    return { partitionKey: 'PK', sortKey: 'SK' }
+  }
+
+  getIndex(indexType: IndexType, indexName: string): DbIndex<ChatConnectionFields> | undefined {
+    return this.getIndexDefinitions()[indexType]?.[indexName]
+  }
+
+  fromDto(connectionDto: ChatConnectionDTO): ChatConnectionFields {
+    const { connectionId, userId, ...remainingData } = connectionDto
+
+    return {
+      PK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`,
+      SK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`,
+      GSI1PK: `${CHAT_CONNECTION_GSI1PK_PREFIX}#${userId}`,
+      GSI1SK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`,
+      ...remainingData
+    }
+  }
+
+  toDto(dbFields: ChatConnectionFields): ChatConnectionDTO {
+    const { PK, SK, GSI1PK, GSI1SK, ...remainingFields } = dbFields
+
+    return {
+      ...remainingFields,
+      connectionId: PK.replace(`${CHAT_CONNECTION_PK_PREFIX}#`, ''),
+      userId: GSI1PK.replace(`${CHAT_CONNECTION_GSI1PK_PREFIX}#`, '')
+    }
+  }
+}

--- a/core/services/aws/commons/ddbModels/ChatMembershipModel.ts
+++ b/core/services/aws/commons/ddbModels/ChatMembershipModel.ts
@@ -1,0 +1,56 @@
+import type { ChatMembershipDTO } from '../../../../../commons/dto/ChatDTO'
+import type {
+  DbModelDtoAdapter,
+  HasTimeLog,
+  NosqlModel,
+  DbIndex,
+  IndexDefinitions,
+  IndexType
+} from './DbModelDefinitions'
+
+export const CHAT_MEMBERSHIP_PK_PREFIX = 'CHATUSER'
+export const CHAT_MEMBERSHIP_SK_PREFIX = 'CHANNEL'
+
+// One membership item per participant, so each user lists their channels by base-table PK query.
+export type ChatMembershipFields = Omit<ChatMembershipDTO, 'userId' | 'channelId'> &
+HasTimeLog & {
+  PK: `${typeof CHAT_MEMBERSHIP_PK_PREFIX}#${string}`;
+  SK: `${typeof CHAT_MEMBERSHIP_SK_PREFIX}#${string}`;
+}
+
+export class ChatMembershipModel
+implements
+    NosqlModel<ChatMembershipFields>,
+    DbModelDtoAdapter<ChatMembershipDTO, ChatMembershipFields> {
+  getIndexDefinitions(): IndexDefinitions<ChatMembershipFields> {
+    return {}
+  }
+
+  getPrimaryIndex(): DbIndex<ChatMembershipFields> {
+    return { partitionKey: 'PK', sortKey: 'SK' }
+  }
+
+  getIndex(indexType: IndexType, indexName: string): DbIndex<ChatMembershipFields> | undefined {
+    return this.getIndexDefinitions()[indexType]?.[indexName]
+  }
+
+  fromDto(membershipDto: ChatMembershipDTO): ChatMembershipFields {
+    const { userId, channelId, ...remainingData } = membershipDto
+
+    return {
+      PK: `${CHAT_MEMBERSHIP_PK_PREFIX}#${userId}`,
+      SK: `${CHAT_MEMBERSHIP_SK_PREFIX}#${channelId}`,
+      ...remainingData
+    }
+  }
+
+  toDto(dbFields: ChatMembershipFields): ChatMembershipDTO {
+    const { PK, SK, ...remainingFields } = dbFields
+
+    return {
+      ...remainingFields,
+      userId: PK.replace(`${CHAT_MEMBERSHIP_PK_PREFIX}#`, ''),
+      channelId: SK.replace(`${CHAT_MEMBERSHIP_SK_PREFIX}#`, '')
+    }
+  }
+}

--- a/core/services/aws/commons/ddbModels/ChatMessageModel.ts
+++ b/core/services/aws/commons/ddbModels/ChatMessageModel.ts
@@ -1,0 +1,63 @@
+import type { ChatMessageDTO } from '../../../../../commons/dto/ChatDTO'
+import type {
+  DbModelDtoAdapter,
+  HasTimeLog,
+  NosqlModel,
+  DbIndex,
+  IndexDefinitions,
+  IndexType
+} from './DbModelDefinitions'
+
+export const CHAT_MESSAGE_PK_PREFIX = 'CHATMSG'
+export const CHAT_MESSAGE_TTL_DAYS = 90
+const SECONDS_PER_DAY = 24 * 60 * 60
+
+// Messages live under a per-channel partition, sorted by the time-ordered messageId (ULID/ISO)
+// for newest-first paging, and carry a DynamoDB TTL attribute for the 90-day purge.
+export type ChatMessageFields = Omit<ChatMessageDTO, 'channelId' | 'messageId'> &
+HasTimeLog & {
+  PK: `${typeof CHAT_MESSAGE_PK_PREFIX}#${string}`;
+  SK: `${string}`;
+  ttl: number;
+}
+
+export class ChatMessageModel
+implements
+    NosqlModel<ChatMessageFields>,
+    DbModelDtoAdapter<ChatMessageDTO, ChatMessageFields> {
+  getIndexDefinitions(): IndexDefinitions<ChatMessageFields> {
+    return {}
+  }
+
+  getPrimaryIndex(): DbIndex<ChatMessageFields> {
+    return { partitionKey: 'PK', sortKey: 'SK' }
+  }
+
+  getIndex(indexType: IndexType, indexName: string): DbIndex<ChatMessageFields> | undefined {
+    return this.getIndexDefinitions()[indexType]?.[indexName]
+  }
+
+  fromDto(messageDto: ChatMessageDTO): ChatMessageFields {
+    const { channelId, messageId, ttl, createdAt, ...remainingData } = messageDto
+    const ttlValue = ttl
+      ?? Math.floor(new Date(createdAt).getTime() / 1000) + CHAT_MESSAGE_TTL_DAYS * SECONDS_PER_DAY
+
+    return {
+      PK: `${CHAT_MESSAGE_PK_PREFIX}#${channelId}`,
+      SK: messageId,
+      ttl: ttlValue,
+      createdAt,
+      ...remainingData
+    }
+  }
+
+  toDto(dbFields: ChatMessageFields): ChatMessageDTO {
+    const { PK, SK, ...remainingFields } = dbFields
+
+    return {
+      ...remainingFields,
+      channelId: PK.replace(`${CHAT_MESSAGE_PK_PREFIX}#`, ''),
+      messageId: SK
+    }
+  }
+}

--- a/core/services/aws/commons/ddbOperations/ChatConnectionDynamoDbOperations.ts
+++ b/core/services/aws/commons/ddbOperations/ChatConnectionDynamoDbOperations.ts
@@ -1,0 +1,68 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  DeleteCommand,
+  QueryCommand
+} from '@aws-sdk/lib-dynamodb'
+import type { ChatConnectionDTO } from '../../../../../commons/dto/ChatDTO'
+import type ChatConnectionRepository from '../../../../application/models/policies/repositories/ChatConnectionRepository'
+import {
+  ChatConnectionModel,
+  CHAT_CONNECTION_PK_PREFIX,
+  CHAT_CONNECTION_GSI1PK_PREFIX
+} from '../ddbModels/ChatConnectionModel'
+import type { ChatConnectionFields } from '../ddbModels/ChatConnectionModel'
+
+// Live WebSocket connections keyed by connectionId ($disconnect carries only connectionId), with
+// GSI1 on userId so a message can fan out to all of a recipient's open connections.
+export default class ChatConnectionDynamoDbOperations implements ChatConnectionRepository {
+  private readonly model = new ChatConnectionModel()
+
+  constructor(
+    private readonly tableName: string,
+    region: string,
+    private readonly client = DynamoDBDocumentClient.from(new DynamoDBClient({ region }))
+  ) {}
+
+  async put(connection: ChatConnectionDTO): Promise<ChatConnectionDTO> {
+    const item = this.model.fromDto(connection)
+    await this.client.send(new PutCommand({
+      TableName: this.tableName,
+      Item: item
+    }))
+
+    return this.model.toDto(item)
+  }
+
+  async deleteByConnectionId(connectionId: string): Promise<void> {
+    await this.client.send(new DeleteCommand({
+      TableName: this.tableName,
+      Key: {
+        PK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`,
+        SK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`
+      }
+    }))
+  }
+
+  async queryByUserId(userId: string): Promise<ChatConnectionDTO[]> {
+    const gsiIndex = this.model.getIndex('GSI', 'GSI1')
+    if (gsiIndex === undefined) {
+      throw new Error('GSI1 index not found on ChatConnectionModel.')
+    }
+
+    const result = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      IndexName: 'GSI1',
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': String(gsiIndex.partitionKey) },
+      ExpressionAttributeValues: {
+        ':pk': `${CHAT_CONNECTION_GSI1PK_PREFIX}#${userId}`
+      }
+    }))
+
+    return (result.Items ?? []).map(
+      (item) => this.model.toDto(item as ChatConnectionFields)
+    )
+  }
+}

--- a/core/services/aws/commons/ddbOperations/ChatConnectionDynamoDbOperations.ts
+++ b/core/services/aws/commons/ddbOperations/ChatConnectionDynamoDbOperations.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
   DeleteCommand,
+  GetCommand,
   QueryCommand
 } from '@aws-sdk/lib-dynamodb'
 import type { ChatConnectionDTO } from '../../../../../commons/dto/ChatDTO'
@@ -33,6 +34,21 @@ export default class ChatConnectionDynamoDbOperations implements ChatConnectionR
     }))
 
     return this.model.toDto(item)
+  }
+
+  async getByConnectionId(connectionId: string): Promise<ChatConnectionDTO | null> {
+    const result = await this.client.send(new GetCommand({
+      TableName: this.tableName,
+      Key: {
+        PK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`,
+        SK: `${CHAT_CONNECTION_PK_PREFIX}#${connectionId}`
+      }
+    }))
+    if (result.Item === null || result.Item === undefined) {
+      return null
+    }
+
+    return this.model.toDto(result.Item as ChatConnectionFields)
   }
 
   async deleteByConnectionId(connectionId: string): Promise<void> {

--- a/core/services/aws/commons/ddbOperations/ChatDynamoDbOperations.ts
+++ b/core/services/aws/commons/ddbOperations/ChatDynamoDbOperations.ts
@@ -1,0 +1,250 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  UpdateCommand,
+  GetCommand,
+  QueryCommand
+} from '@aws-sdk/lib-dynamodb'
+import { ChatChannelStatus } from '../../../../../commons/dto/ChatDTO'
+import type {
+  ChatChannelDTO,
+  ChatMembershipDTO,
+  ChatMessageDTO
+} from '../../../../../commons/dto/ChatDTO'
+import type ChatRepository from '../../../../application/models/policies/repositories/ChatRepository'
+import type { ChatHistoryPage } from '../../../../application/models/policies/repositories/ChatRepository'
+import {
+  ChatChannelModel,
+  CHAT_CHANNEL_PK_PREFIX,
+  CHAT_CHANNEL_SK_PREFIX
+} from '../ddbModels/ChatChannelModel'
+import type { ChatChannelFields } from '../ddbModels/ChatChannelModel'
+import {
+  ChatMembershipModel,
+  CHAT_MEMBERSHIP_PK_PREFIX,
+  CHAT_MEMBERSHIP_SK_PREFIX
+} from '../ddbModels/ChatMembershipModel'
+import type { ChatMembershipFields } from '../ddbModels/ChatMembershipModel'
+import {
+  ChatMessageModel,
+  CHAT_MESSAGE_PK_PREFIX
+} from '../ddbModels/ChatMessageModel'
+import type { ChatMessageFields } from '../ddbModels/ChatMessageModel'
+
+// Composite adapter for the chat channel, per-participant membership, and message item shapes,
+// which share the single table but are distinct entities (so this does not extend the single-model
+// DynamoDbTableOperations base).
+export default class ChatDynamoDbOperations implements ChatRepository {
+  private readonly channelModel = new ChatChannelModel()
+  private readonly membershipModel = new ChatMembershipModel()
+  private readonly messageModel = new ChatMessageModel()
+
+  constructor(
+    private readonly tableName: string,
+    region: string,
+    private readonly client = DynamoDBDocumentClient.from(new DynamoDBClient({ region }))
+  ) {}
+
+  private channelKey(seekerId: string, requestPostId: string, donorId: string): {
+    PK: string;
+    SK: string;
+  } {
+    return {
+      PK: `${CHAT_CHANNEL_PK_PREFIX}#${seekerId}#${requestPostId}`,
+      SK: `${CHAT_CHANNEL_SK_PREFIX}#${donorId}`
+    }
+  }
+
+  private membershipKey(userId: string, channelId: string): { PK: string; SK: string } {
+    return {
+      PK: `${CHAT_MEMBERSHIP_PK_PREFIX}#${userId}`,
+      SK: `${CHAT_MEMBERSHIP_SK_PREFIX}#${channelId}`
+    }
+  }
+
+  // Create-or-reopen: sets status to OPEN and refreshes the context snapshot, preserving the
+  // original createdAt and any existing lastMessageAt so re-accept does not wipe conversation state.
+  async upsertChannelOpen(channel: ChatChannelDTO): Promise<ChatChannelDTO> {
+    const result = await this.client.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: this.channelKey(channel.seekerId, channel.requestPostId, channel.donorId),
+      UpdateExpression:
+        'SET #status = :status, #context = :context, #createdAt = if_not_exists(#createdAt, :createdAt)',
+      ExpressionAttributeNames: {
+        '#status': 'status',
+        '#context': 'context',
+        '#createdAt': 'createdAt'
+      },
+      ExpressionAttributeValues: {
+        ':status': ChatChannelStatus.OPEN,
+        ':context': channel.context,
+        ':createdAt': channel.createdAt
+      },
+      ReturnValues: 'ALL_NEW'
+    }))
+
+    // ALL_NEW returns the persisted item, so on a re-open the original createdAt (preserved by
+    // if_not_exists) is reflected rather than the caller-supplied timestamp.
+    return this.channelModel.toDto(result.Attributes as ChatChannelFields)
+  }
+
+  // Conditional lock: no-op when the channel does not exist (so a REMOVE pipe for an unaccepted
+  // request never materialises a phantom locked record).
+  async lockChannel(seekerId: string, requestPostId: string, donorId: string): Promise<void> {
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: this.channelKey(seekerId, requestPostId, donorId),
+        UpdateExpression: 'SET #status = :status',
+        ConditionExpression: 'attribute_exists(PK)',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: { ':status': ChatChannelStatus.LOCKED }
+      }))
+    } catch (error) {
+      if (!(error instanceof ConditionalCheckFailedException)) {
+        throw error
+      }
+    }
+  }
+
+  async listChannelsForRequest(
+    seekerId: string,
+    requestPostId: string
+  ): Promise<ChatChannelDTO[]> {
+    const result = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'PK' },
+      ExpressionAttributeValues: {
+        ':pk': `${CHAT_CHANNEL_PK_PREFIX}#${seekerId}#${requestPostId}`
+      }
+    }))
+
+    return (result.Items ?? []).map(
+      (item) => this.channelModel.toDto(item as ChatChannelFields)
+    )
+  }
+
+  async getChannel(
+    seekerId: string,
+    requestPostId: string,
+    donorId: string
+  ): Promise<ChatChannelDTO | null> {
+    const result = await this.client.send(new GetCommand({
+      TableName: this.tableName,
+      Key: this.channelKey(seekerId, requestPostId, donorId)
+    }))
+    if (result.Item === null || result.Item === undefined) {
+      return null
+    }
+
+    return this.channelModel.toDto(result.Item as ChatChannelFields)
+  }
+
+  async updateChannelLastMessage(
+    seekerId: string,
+    requestPostId: string,
+    donorId: string,
+    lastMessageAt: string
+  ): Promise<void> {
+    await this.client.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: this.channelKey(seekerId, requestPostId, donorId),
+      UpdateExpression: 'SET #lastMessageAt = :lastMessageAt',
+      ExpressionAttributeNames: { '#lastMessageAt': 'lastMessageAt' },
+      ExpressionAttributeValues: { ':lastMessageAt': lastMessageAt }
+    }))
+  }
+
+  // Upserts the participant's membership, preserving lastReadAt/lastMessageAt across a re-open.
+  async upsertMembership(membership: ChatMembershipDTO): Promise<ChatMembershipDTO> {
+    await this.client.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: this.membershipKey(membership.userId, membership.channelId),
+      UpdateExpression: 'SET #role = :role, #createdAt = if_not_exists(#createdAt, :createdAt)',
+      ExpressionAttributeNames: { '#role': 'role', '#createdAt': 'createdAt' },
+      ExpressionAttributeValues: {
+        ':role': membership.role,
+        ':createdAt': membership.createdAt
+      }
+    }))
+
+    return membership
+  }
+
+  async listMembershipsByUser(userId: string): Promise<ChatMembershipDTO[]> {
+    const result = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: '#pk = :pk AND begins_with(#sk, :sk)',
+      ExpressionAttributeNames: { '#pk': 'PK', '#sk': 'SK' },
+      ExpressionAttributeValues: {
+        ':pk': `${CHAT_MEMBERSHIP_PK_PREFIX}#${userId}`,
+        ':sk': `${CHAT_MEMBERSHIP_SK_PREFIX}#`
+      }
+    }))
+
+    return (result.Items ?? []).map(
+      (item) => this.membershipModel.toDto(item as ChatMembershipFields)
+    )
+  }
+
+  async updateLastRead(userId: string, channelId: string, lastReadAt: string): Promise<void> {
+    await this.client.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: this.membershipKey(userId, channelId),
+      UpdateExpression: 'SET #lastReadAt = :lastReadAt',
+      ExpressionAttributeNames: { '#lastReadAt': 'lastReadAt' },
+      ExpressionAttributeValues: { ':lastReadAt': lastReadAt }
+    }))
+  }
+
+  async updateMembershipLastMessage(
+    userId: string,
+    channelId: string,
+    lastMessageAt: string
+  ): Promise<void> {
+    await this.client.send(new UpdateCommand({
+      TableName: this.tableName,
+      Key: this.membershipKey(userId, channelId),
+      UpdateExpression: 'SET #lastMessageAt = :lastMessageAt',
+      ExpressionAttributeNames: { '#lastMessageAt': 'lastMessageAt' },
+      ExpressionAttributeValues: { ':lastMessageAt': lastMessageAt }
+    }))
+  }
+
+  async putMessage(message: ChatMessageDTO): Promise<ChatMessageDTO> {
+    const item = this.messageModel.fromDto(message)
+    await this.client.send(new PutCommand({
+      TableName: this.tableName,
+      Item: item
+    }))
+
+    return this.messageModel.toDto(item)
+  }
+
+  // Newest-first page: descending sort key order, with the optional cursor for the next page.
+  async queryMessages(
+    channelId: string,
+    limit?: number,
+    exclusiveStartKey?: Record<string, unknown>
+  ): Promise<ChatHistoryPage> {
+    const result = await this.client.send(new QueryCommand({
+      TableName: this.tableName,
+      KeyConditionExpression: '#pk = :pk',
+      ExpressionAttributeNames: { '#pk': 'PK' },
+      ExpressionAttributeValues: { ':pk': `${CHAT_MESSAGE_PK_PREFIX}#${channelId}` },
+      ScanIndexForward: false,
+      ...(limit !== undefined && limit > 0 ? { Limit: limit } : {}),
+      ...(exclusiveStartKey !== undefined ? { ExclusiveStartKey: exclusiveStartKey } : {})
+    }))
+
+    return {
+      items: (result.Items ?? []).map(
+        (item) => this.messageModel.toDto(item as ChatMessageFields)
+      ),
+      lastEvaluatedKey: result.LastEvaluatedKey
+    }
+  }
+}

--- a/core/services/aws/commons/ddbOperations/ChatRateLimitDynamoDbOperations.ts
+++ b/core/services/aws/commons/ddbOperations/ChatRateLimitDynamoDbOperations.ts
@@ -1,0 +1,51 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand
+} from '@aws-sdk/lib-dynamodb'
+import type ChatRateLimitRepository from '../../../../application/models/policies/repositories/ChatRateLimitRepository'
+
+export const CHAT_RATE_LIMIT_PK_PREFIX = 'CHATRATE'
+export const CHAT_RATE_LIMIT_SK_PREFIX = 'WINDOW'
+
+// Atomic per-channel rate limiter: a single conditional UpdateCommand increments the current
+// window's counter only while it is below the limit, so concurrent sends cannot race past it.
+// The counter item carries a TTL so spent windows self-purge.
+export default class ChatRateLimitDynamoDbOperations implements ChatRateLimitRepository {
+  constructor(
+    private readonly tableName: string,
+    region: string,
+    private readonly client = DynamoDBDocumentClient.from(new DynamoDBClient({ region }))
+  ) {}
+
+  async tryConsume(channelId: string, limit: number, windowSeconds: number): Promise<boolean> {
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    const windowStart = nowSeconds - (nowSeconds % windowSeconds)
+
+    try {
+      await this.client.send(new UpdateCommand({
+        TableName: this.tableName,
+        Key: {
+          PK: `${CHAT_RATE_LIMIT_PK_PREFIX}#${channelId}`,
+          SK: `${CHAT_RATE_LIMIT_SK_PREFIX}#${windowStart}`
+        },
+        UpdateExpression: 'SET #ttl = if_not_exists(#ttl, :ttl) ADD #count :one',
+        ConditionExpression: 'attribute_not_exists(#count) OR #count < :limit',
+        ExpressionAttributeNames: { '#count': 'count', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':one': 1,
+          ':limit': limit,
+          ':ttl': windowStart + windowSeconds * 2
+        }
+      }))
+
+      return true
+    } catch (error) {
+      if (error instanceof ConditionalCheckFailedException) {
+        return false
+      }
+      throw error
+    }
+  }
+}

--- a/core/services/aws/package.json
+++ b/core/services/aws/package.json
@@ -16,6 +16,7 @@
     "package-service": "npm run build-service && npm run package"
   },
   "dependencies": {
+    "@aws-sdk/client-apigatewaymanagementapi": "^3.651.1",
     "@aws-sdk/client-cognito-identity-provider": "^3.651.1",
     "@aws-sdk/client-dynamodb": "^3.651.1",
     "@aws-sdk/client-s3": "^3.723.0",
@@ -24,6 +25,7 @@
     "@aws-sdk/client-sns": "^3.682.0",
     "@aws-sdk/client-sqs": "^3.651.1",
     "@aws-sdk/lib-dynamodb": "^3.651.1",
+    "aws-jwt-verify": "^4.0.1",
     "aws-lambda": "^1.0.7"
   },
   "devDependencies": {

--- a/core/services/aws/tests/chat/chatChannelPipeHandlers.test.ts
+++ b/core/services/aws/tests/chat/chatChannelPipeHandlers.test.ts
@@ -1,0 +1,100 @@
+const mockGetDonationRequest = jest.fn()
+const mockOpenChannel = jest.fn()
+const mockLockChannel = jest.fn()
+
+jest.mock('../../../../application/bloodDonationWorkflow/BloodDonationService', () => ({
+  BloodDonationService: jest.fn().mockImplementation(() => ({
+    getDonationRequest: mockGetDonationRequest
+  }))
+}))
+
+jest.mock('../../../../application/chatWorkflow/ChatService', () => ({
+  ChatService: jest.fn().mockImplementation(() => ({
+    openChannel: mockOpenChannel,
+    lockChannel: mockLockChannel
+  }))
+}))
+
+jest.mock('../../commons/ddbOperations/BloodDonationDynamoDbOperations')
+jest.mock('../../commons/ddbOperations/ChatDynamoDbOperations')
+jest.mock('../../commons/ddbOperations/ChatRateLimitDynamoDbOperations')
+jest.mock('../../commons/logger/ServiceLogger', () => ({
+  createServiceLogger: jest.fn(() => ({
+    info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn()
+  }))
+}))
+
+import chatChannelCreator from '../../chat/chatChannelCreator'
+import chatChannelLocker from '../../chat/chatChannelLocker'
+
+const donationPost = {
+  requestedBloodGroup: 'O+',
+  urgencyLevel: 'urgent',
+  donationDateTime: '2026-06-30T10:00:00.000Z',
+  location: 'Dhaka'
+}
+
+const acceptEvent = {
+  PK: 'BLOOD_REQ#seeker-1',
+  SK: 'ACCEPTED#req-1#donor-1',
+  createdAt: '2026-06-26T00:00:00.000Z'
+}
+
+describe('chatChannelCreator', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetDonationRequest.mockResolvedValue(donationPost)
+  })
+
+  test('opens the channel with a context snapshot from the donation post on first accept', async() => {
+    const result = await chatChannelCreator(acceptEvent)
+
+    expect(result).toEqual({ status: 'Success' })
+    expect(mockGetDonationRequest).toHaveBeenCalledWith('seeker-1', 'req-1', acceptEvent.createdAt)
+    expect(mockOpenChannel).toHaveBeenCalledWith({
+      seekerId: 'seeker-1',
+      requestPostId: 'req-1',
+      donorId: 'donor-1',
+      context: {
+        requestedBloodGroup: 'O+',
+        urgencyLevel: 'urgent',
+        donationDateTime: '2026-06-30T10:00:00.000Z',
+        location: 'Dhaka'
+      }
+    })
+  })
+
+  test('re-opens on re-accept (idempotent upsert, called again)', async() => {
+    await chatChannelCreator(acceptEvent)
+    await chatChannelCreator(acceptEvent)
+
+    expect(mockOpenChannel).toHaveBeenCalledTimes(2)
+  })
+
+  test('processes a batched array of pipe records', async() => {
+    await chatChannelCreator([acceptEvent, { ...acceptEvent, SK: 'ACCEPTED#req-1#donor-2' }])
+
+    expect(mockOpenChannel).toHaveBeenCalledTimes(2)
+    expect(mockOpenChannel.mock.calls[1][0].donorId).toBe('donor-2')
+  })
+})
+
+describe('chatChannelLocker', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockLockChannel.mockResolvedValue(undefined)
+  })
+
+  test('locks the donor channel parsed from the REMOVE record', async() => {
+    const result = await chatChannelLocker(acceptEvent)
+
+    expect(result).toEqual({ status: 'Success' })
+    expect(mockLockChannel).toHaveBeenCalledWith('seeker-1', 'req-1', 'donor-1')
+  })
+
+  test('completes without error when the channel does not exist (adapter no-op)', async() => {
+    mockLockChannel.mockResolvedValue(undefined)
+
+    await expect(chatChannelLocker(acceptEvent)).resolves.toEqual({ status: 'Success' })
+  })
+})

--- a/core/services/aws/tests/chat/chatConnectionHandlers.test.ts
+++ b/core/services/aws/tests/chat/chatConnectionHandlers.test.ts
@@ -1,0 +1,107 @@
+const mockPut = jest.fn()
+const mockDeleteByConnectionId = jest.fn()
+const mockVerify = jest.fn()
+
+jest.mock('../../commons/ddbOperations/ChatConnectionDynamoDbOperations', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    put: mockPut,
+    deleteByConnectionId: mockDeleteByConnectionId,
+    queryByUserId: jest.fn()
+  }))
+}))
+
+jest.mock('aws-jwt-verify', () => ({
+  CognitoJwtVerifier: { create: jest.fn(() => ({ verify: mockVerify })) }
+}))
+
+jest.mock('../../commons/logger/ServiceLogger', () => ({
+  createServiceLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn()
+  }))
+}))
+
+import chatConnect from '../../chat/chatConnect'
+import chatDisconnect from '../../chat/chatDisconnect'
+import chatConnectAuthorizer from '../../chat/chatConnectAuthorizer'
+
+describe('chatConnect', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('stores the connection carrying userId from the authorizer context', async() => {
+    const result = await chatConnect({
+      requestContext: { connectionId: 'conn-1', authorizer: { userId: 'user-1' } }
+    })
+
+    expect(result.statusCode).toBe(200)
+    expect(mockPut).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'conn-1', userId: 'user-1' })
+    )
+  })
+
+  test('stores multiple connections for the same user', async() => {
+    await chatConnect({ requestContext: { connectionId: 'conn-1', authorizer: { userId: 'user-1' } } })
+    await chatConnect({ requestContext: { connectionId: 'conn-2', authorizer: { userId: 'user-1' } } })
+
+    expect(mockPut).toHaveBeenCalledTimes(2)
+    expect(mockPut.mock.calls[0][0].connectionId).toBe('conn-1')
+    expect(mockPut.mock.calls[1][0].connectionId).toBe('conn-2')
+  })
+
+  test('rejects with 401 when the authorizer context has no userId', async() => {
+    const result = await chatConnect({ requestContext: { connectionId: 'conn-1', authorizer: {} } })
+
+    expect(result.statusCode).toBe(401)
+    expect(mockPut).not.toHaveBeenCalled()
+  })
+})
+
+describe('chatDisconnect', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('deletes the connection using only the connectionId', async() => {
+    const result = await chatDisconnect({ requestContext: { connectionId: 'conn-1' } })
+
+    expect(result.statusCode).toBe(200)
+    expect(mockDeleteByConnectionId).toHaveBeenCalledWith('conn-1')
+  })
+})
+
+describe('chatConnectAuthorizer', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('returns an Allow policy with userId context for a valid token', async() => {
+    mockVerify.mockResolvedValue({ sub: 'user-1' })
+
+    const result = await chatConnectAuthorizer({
+      methodArn: 'arn:aws:execute-api:region:acct:apiId/stage/$connect',
+      queryStringParameters: { token: 'good-token' }
+    })
+
+    expect(result.policyDocument.Statement[0].Effect).toBe('Allow')
+    expect(result.principalId).toBe('user-1')
+    expect(result.context).toEqual({ userId: 'user-1' })
+  })
+
+  test('returns a Deny policy when verification fails', async() => {
+    mockVerify.mockRejectedValue(new Error('invalid'))
+
+    const result = await chatConnectAuthorizer({
+      methodArn: 'arn:method',
+      queryStringParameters: { token: 'bad-token' }
+    })
+
+    expect(result.policyDocument.Statement[0].Effect).toBe('Deny')
+    expect(result.context).toBeUndefined()
+  })
+
+  test('returns a Deny policy when the token query param is missing', async() => {
+    const result = await chatConnectAuthorizer({ methodArn: 'arn:method', queryStringParameters: null })
+
+    expect(result.policyDocument.Statement[0].Effect).toBe('Deny')
+    expect(mockVerify).not.toHaveBeenCalled()
+  })
+})

--- a/core/services/aws/tests/chat/chatRestHandlers.test.ts
+++ b/core/services/aws/tests/chat/chatRestHandlers.test.ts
@@ -52,9 +52,12 @@ describe('chatGetHistory', () => {
     expect(mockGetHistory).not.toHaveBeenCalled()
   })
 
-  test('returns a paginated page for a participant', async() => {
-    const page = { items: [{ messageId: 'm2' }, { messageId: 'm1' }], lastEvaluatedKey: { SK: 'm1' } }
-    mockGetHistory.mockResolvedValue(page)
+  test('returns a paginated page plus the channel context for a participant', async() => {
+    const historyResult = {
+      channel: { status: 'OPEN', context: { requestedBloodGroup: 'O+' } },
+      page: { items: [{ messageId: 'm2' }, { messageId: 'm1' }], lastEvaluatedKey: { SK: 'm1' } }
+    }
+    mockGetHistory.mockResolvedValue(historyResult)
 
     const cursor = { SK: 'm3' }
     const result = await chatGetHistory({
@@ -67,7 +70,9 @@ describe('chatGetHistory', () => {
 
     expect(result.statusCode).toBe(200)
     expect(mockGetHistory).toHaveBeenCalledWith(CHANNEL_ID, 25, cursor)
-    expect(JSON.parse(result.body).data.items).toHaveLength(2)
+    const body = JSON.parse(result.body)
+    expect(body.data.page.items).toHaveLength(2)
+    expect(body.data.channel.status).toBe('OPEN')
   })
 })
 

--- a/core/services/aws/tests/chat/chatRestHandlers.test.ts
+++ b/core/services/aws/tests/chat/chatRestHandlers.test.ts
@@ -1,0 +1,92 @@
+const mockListChannels = jest.fn()
+const mockGetHistory = jest.fn()
+const mockMarkRead = jest.fn()
+
+jest.mock('../../../../application/chatWorkflow/ChatService', () => ({
+  ChatService: jest.fn().mockImplementation(() => ({
+    listChannels: mockListChannels,
+    getHistory: mockGetHistory,
+    markRead: mockMarkRead
+  }))
+}))
+jest.mock('../../commons/ddbOperations/ChatDynamoDbOperations')
+jest.mock('../../commons/ddbOperations/ChatRateLimitDynamoDbOperations')
+jest.mock('../../commons/logger/HttpLogger', () => ({
+  createHTTPLogger: jest.fn(() => ({
+    info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn()
+  }))
+}))
+
+import chatListChannels from '../../chat/chatListChannels'
+import chatGetHistory from '../../chat/chatGetHistory'
+import chatMarkRead from '../../chat/chatMarkRead'
+import { ChatRole } from '../../../../../commons/dto/ChatDTO'
+
+const CHANNEL_ID = 'seeker-1#req-1#donor-1'
+const loggerAttrs = { apiGwRequestId: 'api-1', cloudFrontRequestId: 'cf-1' }
+
+describe('chatListChannels', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('returns the caller\'s channels across both roles', async() => {
+    mockListChannels.mockResolvedValue([
+      { userId: 'user-x', channelId: 'user-x#r#d', role: ChatRole.SEEKER, createdAt: 'x' },
+      { userId: 'user-x', channelId: 's#r#user-x', role: ChatRole.DONOR, createdAt: 'x' }
+    ])
+
+    const result = await chatListChannels({ userId: 'user-x', ...loggerAttrs })
+
+    expect(result.statusCode).toBe(200)
+    expect(mockListChannels).toHaveBeenCalledWith('user-x')
+    expect(JSON.parse(result.body).data).toHaveLength(2)
+  })
+})
+
+describe('chatGetHistory', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('rejects a non-participant with 401', async() => {
+    const result = await chatGetHistory({ userId: 'intruder', channelId: CHANNEL_ID, ...loggerAttrs })
+
+    expect(result.statusCode).toBe(401)
+    expect(mockGetHistory).not.toHaveBeenCalled()
+  })
+
+  test('returns a paginated page for a participant', async() => {
+    const page = { items: [{ messageId: 'm2' }, { messageId: 'm1' }], lastEvaluatedKey: { SK: 'm1' } }
+    mockGetHistory.mockResolvedValue(page)
+
+    const cursor = { SK: 'm3' }
+    const result = await chatGetHistory({
+      userId: 'donor-1',
+      channelId: CHANNEL_ID,
+      limit: 25,
+      exclusiveStartKey: cursor,
+      ...loggerAttrs
+    })
+
+    expect(result.statusCode).toBe(200)
+    expect(mockGetHistory).toHaveBeenCalledWith(CHANNEL_ID, 25, cursor)
+    expect(JSON.parse(result.body).data.items).toHaveLength(2)
+  })
+})
+
+describe('chatMarkRead', () => {
+  beforeEach(() => jest.clearAllMocks())
+
+  test('rejects a non-participant with 401', async() => {
+    const result = await chatMarkRead({ userId: 'intruder', channelId: CHANNEL_ID, ...loggerAttrs })
+
+    expect(result.statusCode).toBe(401)
+    expect(mockMarkRead).not.toHaveBeenCalled()
+  })
+
+  test('marks read for the calling participant only', async() => {
+    mockMarkRead.mockResolvedValue(undefined)
+
+    const result = await chatMarkRead({ userId: 'seeker-1', channelId: CHANNEL_ID, ...loggerAttrs })
+
+    expect(result.statusCode).toBe(200)
+    expect(mockMarkRead).toHaveBeenCalledWith('seeker-1', CHANNEL_ID)
+  })
+})

--- a/core/services/aws/tests/chat/chatSendMessage.test.ts
+++ b/core/services/aws/tests/chat/chatSendMessage.test.ts
@@ -1,0 +1,131 @@
+const mockGetByConnectionId = jest.fn()
+const mockQueryByUserId = jest.fn()
+const mockDeleteByConnectionId = jest.fn()
+const mockSendMessage = jest.fn()
+const mockPostToConnection = jest.fn()
+const mockQueue = jest.fn()
+
+jest.mock('../../commons/ddbOperations/ChatConnectionDynamoDbOperations', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({
+    getByConnectionId: mockGetByConnectionId,
+    queryByUserId: mockQueryByUserId,
+    deleteByConnectionId: mockDeleteByConnectionId
+  }))
+}))
+jest.mock('../../commons/ddbOperations/ChatDynamoDbOperations')
+jest.mock('../../commons/ddbOperations/ChatRateLimitDynamoDbOperations')
+jest.mock('../../../../application/chatWorkflow/ChatService', () => ({
+  ChatService: jest.fn().mockImplementation(() => ({ sendMessage: mockSendMessage }))
+}))
+jest.mock('../../commons/apiGateway/WebSocketOperations', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ postToConnection: mockPostToConnection }))
+}))
+jest.mock('../../commons/sqs/SQSOperations', () => ({
+  __esModule: true,
+  default: jest.fn().mockImplementation(() => ({ queue: mockQueue }))
+}))
+jest.mock('../../commons/logger/ServiceLogger', () => ({
+  createServiceLogger: jest.fn(() => ({
+    info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn()
+  }))
+}))
+
+import chatSendMessage from '../../chat/chatSendMessage'
+import NotChannelParticipantError from '../../../../application/chatWorkflow/NotChannelParticipantError'
+import { NotificationType } from '../../../../../commons/dto/NotificationDTO'
+
+const CHANNEL_ID = 'seeker-1#req-1#donor-1'
+
+const savedMessage = {
+  channelId: CHANNEL_ID,
+  messageId: 'msg-1',
+  senderId: 'seeker-1',
+  content: 'hello',
+  createdAt: '2026-06-26T00:00:00.000Z'
+}
+
+const event = (body: unknown) => ({
+  requestContext: { connectionId: 'conn-sender', domainName: 'ws.example.com', stage: 'dev' },
+  body: JSON.stringify(body)
+})
+
+describe('chatSendMessage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockGetByConnectionId.mockResolvedValue({ connectionId: 'conn-sender', userId: 'seeker-1' })
+    mockSendMessage.mockResolvedValue(savedMessage)
+    mockPostToConnection.mockResolvedValue({ gone: false })
+  })
+
+  test('rejects a non-participant with the error code and does not fan out', async() => {
+    mockSendMessage.mockRejectedValue(
+      new NotChannelParticipantError('not a participant', 401)
+    )
+
+    const result = await chatSendMessage(event({ channelId: CHANNEL_ID, content: 'hi' }))
+
+    expect(result.statusCode).toBe(401)
+    expect(mockPostToConnection).not.toHaveBeenCalled()
+    expect(mockQueue).not.toHaveBeenCalled()
+  })
+
+  test('rejects with 400 on a malformed body', async() => {
+    const result = await chatSendMessage(event({ channelId: CHANNEL_ID }))
+
+    expect(result.statusCode).toBe(400)
+    expect(mockSendMessage).not.toHaveBeenCalled()
+  })
+
+  test('delivers to both participants\' live connections', async() => {
+    mockQueryByUserId.mockImplementation(async(userId: string) =>
+      userId === 'seeker-1'
+        ? [{ connectionId: 'conn-sender', userId }]
+        : [{ connectionId: 'conn-donor', userId }]
+    )
+
+    const result = await chatSendMessage(event({ channelId: CHANNEL_ID, content: 'hello' }))
+
+    expect(result.statusCode).toBe(200)
+    expect(mockPostToConnection).toHaveBeenCalledWith('conn-sender', savedMessage)
+    expect(mockPostToConnection).toHaveBeenCalledWith('conn-donor', savedMessage)
+    expect(mockQueue).not.toHaveBeenCalled()
+  })
+
+  test('prunes a stale connection on GoneException', async() => {
+    mockQueryByUserId.mockImplementation(async(userId: string) =>
+      userId === 'donor-1' ? [{ connectionId: 'conn-stale', userId }] : []
+    )
+    mockPostToConnection.mockResolvedValue({ gone: true })
+
+    await chatSendMessage(event({ channelId: CHANNEL_ID, content: 'hello' }))
+
+    expect(mockDeleteByConnectionId).toHaveBeenCalledWith('conn-stale')
+  })
+
+  test('enqueues a CHAT_MESSAGE push for an offline recipient', async() => {
+    mockQueryByUserId.mockImplementation(async(userId: string) =>
+      userId === 'seeker-1' ? [{ connectionId: 'conn-sender', userId }] : []
+    )
+
+    await chatSendMessage(event({ channelId: CHANNEL_ID, content: 'hello' }))
+
+    expect(mockQueue).toHaveBeenCalledTimes(1)
+    const [notification] = mockQueue.mock.calls[0]
+    expect(notification).toEqual(expect.objectContaining({
+      userId: 'donor-1',
+      type: NotificationType.CHAT_MESSAGE
+    }))
+  })
+
+  test('does not enqueue a push for the offline sender themselves', async() => {
+    mockQueryByUserId.mockImplementation(async(userId: string) =>
+      userId === 'donor-1' ? [{ connectionId: 'conn-donor', userId }] : []
+    )
+
+    await chatSendMessage(event({ channelId: CHANNEL_ID, content: 'hello' }))
+
+    expect(mockQueue).not.toHaveBeenCalled()
+  })
+})

--- a/core/services/aws/tests/commons/ddb/ChatConnectionDynamoDbOperations.test.ts
+++ b/core/services/aws/tests/commons/ddb/ChatConnectionDynamoDbOperations.test.ts
@@ -1,0 +1,62 @@
+import ChatConnectionDynamoDbOperations from '../../../commons/ddbOperations/ChatConnectionDynamoDbOperations'
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  DeleteCommand,
+  QueryCommand
+} from '@aws-sdk/lib-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import type { ChatConnectionDTO } from '../../../../../../commons/dto/ChatDTO'
+
+const TABLE = 'TestTable'
+const REGION = 'ap-south-1'
+
+describe('ChatConnectionDynamoDbOperations', () => {
+  const ddbMock = mockClient(DynamoDBDocumentClient)
+  const operations = new ChatConnectionDynamoDbOperations(TABLE, REGION)
+
+  beforeEach(() => {
+    ddbMock.reset()
+  })
+
+  test('put stores the connection keyed by connectionId with userId on GSI1', async() => {
+    ddbMock.on(PutCommand).resolves({})
+    const connection: ChatConnectionDTO = {
+      connectionId: 'conn-1',
+      userId: 'user-1',
+      createdAt: '2026-06-26T00:00:00.000Z'
+    }
+
+    await operations.put(connection)
+
+    const item = ddbMock.commandCalls(PutCommand)[0].args[0].input.Item as Record<string, string>
+    expect(item.PK).toBe('CONNECTION#conn-1')
+    expect(item.SK).toBe('CONNECTION#conn-1')
+    expect(item.GSI1PK).toBe('CHATUSER#user-1')
+  })
+
+  test('deleteByConnectionId deletes using only the connectionId', async() => {
+    ddbMock.on(DeleteCommand).resolves({})
+
+    await operations.deleteByConnectionId('conn-1')
+
+    const input = ddbMock.commandCalls(DeleteCommand)[0].args[0].input
+    expect(input.Key).toEqual({ PK: 'CONNECTION#conn-1', SK: 'CONNECTION#conn-1' })
+  })
+
+  test('queryByUserId fans out over all of a user\'s connections via GSI1', async() => {
+    ddbMock.on(QueryCommand).resolves({
+      Items: [
+        { PK: 'CONNECTION#conn-1', SK: 'CONNECTION#conn-1', GSI1PK: 'CHATUSER#user-1', GSI1SK: 'CONNECTION#conn-1', createdAt: 'x' },
+        { PK: 'CONNECTION#conn-2', SK: 'CONNECTION#conn-2', GSI1PK: 'CHATUSER#user-1', GSI1SK: 'CONNECTION#conn-2', createdAt: 'y' }
+      ]
+    })
+
+    const connections = await operations.queryByUserId('user-1')
+
+    const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input
+    expect(input.IndexName).toBe('GSI1')
+    expect(input.ExpressionAttributeValues?.[':pk']).toBe('CHATUSER#user-1')
+    expect(connections.map((c) => c.connectionId)).toEqual(['conn-1', 'conn-2'])
+  })
+})

--- a/core/services/aws/tests/commons/ddb/ChatConnectionDynamoDbOperations.test.ts
+++ b/core/services/aws/tests/commons/ddb/ChatConnectionDynamoDbOperations.test.ts
@@ -3,6 +3,7 @@ import {
   DynamoDBDocumentClient,
   PutCommand,
   DeleteCommand,
+  GetCommand,
   QueryCommand
 } from '@aws-sdk/lib-dynamodb'
 import { mockClient } from 'aws-sdk-client-mock'
@@ -42,6 +43,30 @@ describe('ChatConnectionDynamoDbOperations', () => {
 
     const input = ddbMock.commandCalls(DeleteCommand)[0].args[0].input
     expect(input.Key).toEqual({ PK: 'CONNECTION#conn-1', SK: 'CONNECTION#conn-1' })
+  })
+
+  test('getByConnectionId resolves the userId for a live connection', async() => {
+    ddbMock.on(GetCommand).resolves({
+      Item: {
+        PK: 'CONNECTION#conn-1',
+        SK: 'CONNECTION#conn-1',
+        GSI1PK: 'CHATUSER#user-1',
+        GSI1SK: 'CONNECTION#conn-1',
+        createdAt: 'x'
+      }
+    })
+
+    const connection = await operations.getByConnectionId('conn-1')
+
+    const input = ddbMock.commandCalls(GetCommand)[0].args[0].input
+    expect(input.Key).toEqual({ PK: 'CONNECTION#conn-1', SK: 'CONNECTION#conn-1' })
+    expect(connection?.userId).toBe('user-1')
+  })
+
+  test('getByConnectionId returns null for an unknown connection', async() => {
+    ddbMock.on(GetCommand).resolves({})
+
+    expect(await operations.getByConnectionId('absent')).toBeNull()
   })
 
   test('queryByUserId fans out over all of a user\'s connections via GSI1', async() => {

--- a/core/services/aws/tests/commons/ddb/ChatDynamoDbOperations.test.ts
+++ b/core/services/aws/tests/commons/ddb/ChatDynamoDbOperations.test.ts
@@ -1,0 +1,234 @@
+import ChatDynamoDbOperations from '../../../commons/ddbOperations/ChatDynamoDbOperations'
+import {
+  DynamoDBDocumentClient,
+  PutCommand,
+  UpdateCommand,
+  GetCommand,
+  QueryCommand
+} from '@aws-sdk/lib-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+import {
+  ChatChannelStatus,
+  ChatRole,
+  buildChannelId
+} from '../../../../../../commons/dto/ChatDTO'
+import type {
+  ChatChannelDTO,
+  ChatMembershipDTO,
+  ChatMessageDTO
+} from '../../../../../../commons/dto/ChatDTO'
+
+const TABLE = 'TestTable'
+const REGION = 'ap-south-1'
+
+describe('ChatDynamoDbOperations', () => {
+  const ddbMock = mockClient(DynamoDBDocumentClient)
+  const operations = new ChatDynamoDbOperations(TABLE, REGION)
+
+  beforeEach(() => {
+    ddbMock.reset()
+  })
+
+  describe('upsertChannelOpen', () => {
+    const channel: ChatChannelDTO = {
+      channelId: buildChannelId('seeker-1', 'req-1', 'donor-1'),
+      seekerId: 'seeker-1',
+      requestPostId: 'req-1',
+      donorId: 'donor-1',
+      status: ChatChannelStatus.OPEN,
+      context: {
+        requestedBloodGroup: 'O+',
+        urgencyLevel: 'urgent',
+        donationDateTime: '2026-06-30T10:00:00.000Z',
+        location: 'Dhaka'
+      },
+      createdAt: '2026-06-26T00:00:00.000Z'
+    }
+
+    test('sets status OPEN and preserves createdAt via if_not_exists on the channel key', async() => {
+      // ALL_NEW echoes the persisted item; the original createdAt differs from the caller's input
+      // to prove the returned DTO reflects the stored (preserved) value on a re-open.
+      ddbMock.on(UpdateCommand).resolves({
+        Attributes: {
+          PK: 'CHANNEL#seeker-1#req-1',
+          SK: 'DONOR#donor-1',
+          status: ChatChannelStatus.OPEN,
+          context: channel.context,
+          createdAt: '2026-06-20T00:00:00.000Z'
+        }
+      })
+
+      const result = await operations.upsertChannelOpen(channel)
+
+      const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      expect(input.Key).toEqual({ PK: 'CHANNEL#seeker-1#req-1', SK: 'DONOR#donor-1' })
+      expect(input.UpdateExpression).toContain('#status = :status')
+      expect(input.UpdateExpression).toContain('if_not_exists(#createdAt, :createdAt)')
+      expect(input.ExpressionAttributeValues?.[':status']).toBe(ChatChannelStatus.OPEN)
+      expect(input.ReturnValues).toBe('ALL_NEW')
+      expect(result.status).toBe(ChatChannelStatus.OPEN)
+      expect(result.createdAt).toBe('2026-06-20T00:00:00.000Z')
+      expect(result.channelId).toBe('seeker-1#req-1#donor-1')
+    })
+  })
+
+  describe('lockChannel', () => {
+    test('locks an existing channel with attribute_exists guard', async() => {
+      ddbMock.on(UpdateCommand).resolves({})
+
+      await operations.lockChannel('seeker-1', 'req-1', 'donor-1')
+
+      const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      expect(input.ConditionExpression).toBe('attribute_exists(PK)')
+      expect(input.ExpressionAttributeValues?.[':status']).toBe(ChatChannelStatus.LOCKED)
+    })
+
+    test('is a safe no-op when the channel does not exist', async() => {
+      ddbMock.on(UpdateCommand).rejects(
+        new ConditionalCheckFailedException({ message: 'no item', $metadata: {} })
+      )
+
+      await expect(operations.lockChannel('seeker-1', 'req-1', 'absent')).resolves.toBeUndefined()
+    })
+
+    test('rethrows non-conditional errors', async() => {
+      ddbMock.on(UpdateCommand).rejects(new Error('boom'))
+
+      await expect(operations.lockChannel('seeker-1', 'req-1', 'donor-1')).rejects.toThrow('boom')
+    })
+  })
+
+  describe('listChannelsForRequest', () => {
+    test('queries all channels under the request PK and maps them to DTOs', async() => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { PK: 'CHANNEL#seeker-1#req-1', SK: 'DONOR#donor-1', status: ChatChannelStatus.OPEN, context: {}, createdAt: 'x' },
+          { PK: 'CHANNEL#seeker-1#req-1', SK: 'DONOR#donor-2', status: ChatChannelStatus.LOCKED, context: {}, createdAt: 'y' }
+        ]
+      })
+
+      const channels = await operations.listChannelsForRequest('seeker-1', 'req-1')
+
+      const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input
+      expect(input.ExpressionAttributeValues?.[':pk']).toBe('CHANNEL#seeker-1#req-1')
+      expect(channels.map((c) => c.donorId)).toEqual(['donor-1', 'donor-2'])
+    })
+  })
+
+  describe('getChannel', () => {
+    test('returns null when the channel is absent', async() => {
+      ddbMock.on(GetCommand).resolves({})
+
+      expect(await operations.getChannel('seeker-1', 'req-1', 'donor-1')).toBeNull()
+    })
+
+    test('maps a found channel to a DTO', async() => {
+      ddbMock.on(GetCommand).resolves({
+        Item: {
+          PK: 'CHANNEL#seeker-1#req-1',
+          SK: 'DONOR#donor-1',
+          status: ChatChannelStatus.OPEN,
+          context: {},
+          createdAt: 'x'
+        }
+      })
+
+      const channel = await operations.getChannel('seeker-1', 'req-1', 'donor-1')
+      expect(channel?.seekerId).toBe('seeker-1')
+      expect(channel?.donorId).toBe('donor-1')
+    })
+  })
+
+  describe('membership operations', () => {
+    test('upsertMembership writes role under the user partition preserving createdAt', async() => {
+      ddbMock.on(UpdateCommand).resolves({})
+      const membership: ChatMembershipDTO = {
+        userId: 'user-1',
+        channelId: 'seeker-1#req-1#donor-1',
+        role: ChatRole.DONOR,
+        createdAt: '2026-06-26T00:00:00.000Z'
+      }
+
+      await operations.upsertMembership(membership)
+
+      const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      expect(input.Key).toEqual({ PK: 'CHATUSER#user-1', SK: 'CHANNEL#seeker-1#req-1#donor-1' })
+      expect(input.UpdateExpression).toContain('if_not_exists(#createdAt, :createdAt)')
+    })
+
+    test('listMembershipsByUser queries the user partition with the CHANNEL prefix', async() => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { PK: 'CHATUSER#user-1', SK: 'CHANNEL#seeker-1#req-1#donor-1', role: ChatRole.SEEKER, createdAt: 'x' }
+        ]
+      })
+
+      const memberships = await operations.listMembershipsByUser('user-1')
+
+      const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input
+      expect(input.ExpressionAttributeValues?.[':pk']).toBe('CHATUSER#user-1')
+      expect(input.ExpressionAttributeValues?.[':sk']).toBe('CHANNEL#')
+      expect(memberships[0].channelId).toBe('seeker-1#req-1#donor-1')
+    })
+
+    test('updateLastRead sets only the caller\'s lastReadAt marker', async() => {
+      ddbMock.on(UpdateCommand).resolves({})
+
+      await operations.updateLastRead('user-1', 'seeker-1#req-1#donor-1', '2026-06-26T03:00:00.000Z')
+
+      const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      expect(input.UpdateExpression).toBe('SET #lastReadAt = :lastReadAt')
+      expect(input.Key).toEqual({ PK: 'CHATUSER#user-1', SK: 'CHANNEL#seeker-1#req-1#donor-1' })
+    })
+
+    test('updateMembershipLastMessage bumps the denormalized lastMessageAt', async() => {
+      ddbMock.on(UpdateCommand).resolves({})
+
+      await operations.updateMembershipLastMessage('user-1', 'seeker-1#req-1#donor-1', 'ts')
+
+      const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+      expect(input.UpdateExpression).toBe('SET #lastMessageAt = :lastMessageAt')
+    })
+  })
+
+  describe('message operations', () => {
+    const message: ChatMessageDTO = {
+      channelId: 'seeker-1#req-1#donor-1',
+      messageId: '2026-06-26T00:00:00.000Z#01',
+      senderId: 'user-1',
+      content: 'hello',
+      createdAt: '2026-06-26T00:00:00.000Z'
+    }
+
+    test('putMessage stores under the channel message partition and returns the DTO', async() => {
+      ddbMock.on(PutCommand).resolves({})
+
+      const saved = await operations.putMessage(message)
+
+      const input = ddbMock.commandCalls(PutCommand)[0].args[0].input
+      expect((input.Item as { PK: string }).PK).toBe('CHATMSG#seeker-1#req-1#donor-1')
+      expect(saved.content).toBe('hello')
+    })
+
+    test('queryMessages reads newest-first with the limit and cursor', async() => {
+      ddbMock.on(QueryCommand).resolves({
+        Items: [
+          { PK: 'CHATMSG#seeker-1#req-1#donor-1', SK: 'm2', senderId: 'u', content: 'b', createdAt: 'x', ttl: 1 },
+          { PK: 'CHATMSG#seeker-1#req-1#donor-1', SK: 'm1', senderId: 'u', content: 'a', createdAt: 'y', ttl: 1 }
+        ],
+        LastEvaluatedKey: { PK: 'CHATMSG#seeker-1#req-1#donor-1', SK: 'm1' }
+      })
+
+      const cursor = { PK: 'CHATMSG#seeker-1#req-1#donor-1', SK: 'm3' }
+      const page = await operations.queryMessages('seeker-1#req-1#donor-1', 25, cursor)
+
+      const input = ddbMock.commandCalls(QueryCommand)[0].args[0].input
+      expect(input.ScanIndexForward).toBe(false)
+      expect(input.Limit).toBe(25)
+      expect(input.ExclusiveStartKey).toEqual(cursor)
+      expect(page.items.map((m) => m.messageId)).toEqual(['m2', 'm1'])
+      expect(page.lastEvaluatedKey).toEqual({ PK: 'CHATMSG#seeker-1#req-1#donor-1', SK: 'm1' })
+    })
+  })
+})

--- a/core/services/aws/tests/commons/ddb/ChatRateLimitDynamoDbOperations.test.ts
+++ b/core/services/aws/tests/commons/ddb/ChatRateLimitDynamoDbOperations.test.ts
@@ -1,0 +1,50 @@
+import ChatRateLimitDynamoDbOperations from '../../../commons/ddbOperations/ChatRateLimitDynamoDbOperations'
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand
+} from '@aws-sdk/lib-dynamodb'
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb'
+import { mockClient } from 'aws-sdk-client-mock'
+
+const TABLE = 'TestTable'
+const REGION = 'ap-south-1'
+const CHANNEL_ID = 'seeker-1#req-1#donor-1'
+
+describe('ChatRateLimitDynamoDbOperations', () => {
+  const ddbMock = mockClient(DynamoDBDocumentClient)
+  const operations = new ChatRateLimitDynamoDbOperations(TABLE, REGION)
+
+  beforeEach(() => {
+    ddbMock.reset()
+  })
+
+  test('allows a message via an atomic conditional increment with a TTL', async() => {
+    ddbMock.on(UpdateCommand).resolves({})
+
+    const allowed = await operations.tryConsume(CHANNEL_ID, 60, 60)
+
+    expect(allowed).toBe(true)
+    const input = ddbMock.commandCalls(UpdateCommand)[0].args[0].input
+    expect(input.UpdateExpression).toContain('ADD #count :one')
+    expect(input.ConditionExpression).toBe('attribute_not_exists(#count) OR #count < :limit')
+    expect(input.ExpressionAttributeValues?.[':limit']).toBe(60)
+    expect((input.Key as { PK: string }).PK).toBe(`CHATRATE#${CHANNEL_ID}`)
+    expect(input.ExpressionAttributeValues?.[':ttl']).toBeGreaterThan(0)
+  })
+
+  test('rejects the 61st message in a window when the conditional check fails', async() => {
+    ddbMock.on(UpdateCommand).rejects(
+      new ConditionalCheckFailedException({ message: 'limit reached', $metadata: {} })
+    )
+
+    const allowed = await operations.tryConsume(CHANNEL_ID, 60, 60)
+
+    expect(allowed).toBe(false)
+  })
+
+  test('rethrows unexpected errors', async() => {
+    ddbMock.on(UpdateCommand).rejects(new Error('network'))
+
+    await expect(operations.tryConsume(CHANNEL_ID, 60, 60)).rejects.toThrow('network')
+  })
+})

--- a/core/services/aws/tests/dbModels/ChatModels.test.ts
+++ b/core/services/aws/tests/dbModels/ChatModels.test.ts
@@ -1,0 +1,178 @@
+import {
+  ChatChannelModel,
+  buildChannelId,
+  parseChannelId
+} from '../../commons/ddbModels/ChatChannelModel'
+import { ChatMembershipModel } from '../../commons/ddbModels/ChatMembershipModel'
+import {
+  ChatMessageModel,
+  CHAT_MESSAGE_TTL_DAYS
+} from '../../commons/ddbModels/ChatMessageModel'
+import { ChatConnectionModel } from '../../commons/ddbModels/ChatConnectionModel'
+import {
+  ChatChannelStatus,
+  ChatRole,
+  type ChatChannelDTO,
+  type ChatMembershipDTO,
+  type ChatMessageDTO,
+  type ChatConnectionDTO
+} from '../../../../../commons/dto/ChatDTO'
+
+describe('ChatChannelModel keys (per-request channel query)', () => {
+  const model = new ChatChannelModel()
+  const baseDto: ChatChannelDTO = {
+    channelId: buildChannelId('seeker-1', 'req-1', 'donor-1'),
+    seekerId: 'seeker-1',
+    requestPostId: 'req-1',
+    donorId: 'donor-1',
+    status: ChatChannelStatus.OPEN,
+    context: {
+      requestedBloodGroup: 'O+',
+      urgencyLevel: 'urgent',
+      donationDateTime: '2026-06-30T10:00:00.000Z',
+      location: 'Dhaka'
+    },
+    createdAt: '2026-06-26T00:00:00.000Z'
+  }
+
+  test('keys all of a request\'s channels under one PK, differing by donor SK', () => {
+    const donor1 = model.fromDto(baseDto)
+    const donor2 = model.fromDto({
+      ...baseDto,
+      channelId: buildChannelId('seeker-1', 'req-1', 'donor-2'),
+      donorId: 'donor-2'
+    })
+
+    expect(donor1.PK).toBe('CHANNEL#seeker-1#req-1')
+    expect(donor2.PK).toBe('CHANNEL#seeker-1#req-1')
+    expect(donor1.SK).toBe('DONOR#donor-1')
+    expect(donor2.SK).toBe('DONOR#donor-2')
+  })
+
+  test('round-trips identity and channelId through fromDto/toDto', () => {
+    const dto = model.toDto(model.fromDto(baseDto))
+
+    expect(dto.seekerId).toBe('seeker-1')
+    expect(dto.requestPostId).toBe('req-1')
+    expect(dto.donorId).toBe('donor-1')
+    expect(dto.channelId).toBe('seeker-1#req-1#donor-1')
+    expect(dto.context.location).toBe('Dhaka')
+    expect(dto.status).toBe(ChatChannelStatus.OPEN)
+  })
+
+  test('parseChannelId is the inverse of buildChannelId', () => {
+    expect(parseChannelId(buildChannelId('s', 'r', 'd'))).toEqual({
+      seekerId: 's',
+      requestPostId: 'r',
+      donorId: 'd'
+    })
+  })
+})
+
+describe('ChatMembershipModel keys (per-user membership query)', () => {
+  const model = new ChatMembershipModel()
+  const baseDto: ChatMembershipDTO = {
+    userId: 'user-1',
+    channelId: 'seeker-1#req-1#donor-1',
+    role: ChatRole.SEEKER,
+    createdAt: '2026-06-26T00:00:00.000Z'
+  }
+
+  test('keys each membership under the participant\'s own user partition', () => {
+    const fields = model.fromDto(baseDto)
+
+    expect(fields.PK).toBe('CHATUSER#user-1')
+    expect(fields.SK).toBe('CHANNEL#seeker-1#req-1#donor-1')
+  })
+
+  test('round-trips userId, channelId and role', () => {
+    const dto = model.toDto(model.fromDto({
+      ...baseDto,
+      role: ChatRole.DONOR,
+      lastReadAt: '2026-06-26T01:00:00.000Z'
+    }))
+
+    expect(dto.userId).toBe('user-1')
+    expect(dto.channelId).toBe('seeker-1#req-1#donor-1')
+    expect(dto.role).toBe(ChatRole.DONOR)
+    expect(dto.lastReadAt).toBe('2026-06-26T01:00:00.000Z')
+  })
+})
+
+describe('ChatMessageModel ordering and TTL', () => {
+  const model = new ChatMessageModel()
+  const baseDto: ChatMessageDTO = {
+    channelId: 'seeker-1#req-1#donor-1',
+    messageId: '2026-06-26T00:00:00.000Z#01',
+    senderId: 'user-1',
+    content: 'hello',
+    createdAt: '2026-06-26T00:00:00.000Z'
+  }
+
+  test('partitions by channel and uses the time-ordered messageId as the sort key', () => {
+    const fields = model.fromDto(baseDto)
+
+    expect(fields.PK).toBe('CHATMSG#seeker-1#req-1#donor-1')
+    expect(fields.SK).toBe('2026-06-26T00:00:00.000Z#01')
+  })
+
+  test('a later messageId sorts after an earlier one (newest-first paging relies on SK order)', () => {
+    const earlier = model.fromDto(baseDto)
+    const later = model.fromDto({ ...baseDto, messageId: '2026-06-26T00:00:01.000Z#01' })
+
+    expect(later.SK > earlier.SK).toBe(true)
+  })
+
+  test('derives a TTL 90 days after createdAt when none is supplied', () => {
+    const fields = model.fromDto(baseDto)
+    const expected = Math.floor(new Date(baseDto.createdAt).getTime() / 1000)
+      + CHAT_MESSAGE_TTL_DAYS * 24 * 60 * 60
+
+    expect(fields.ttl).toBe(expected)
+  })
+
+  test('round-trips channelId and messageId', () => {
+    const dto = model.toDto(model.fromDto(baseDto))
+
+    expect(dto.channelId).toBe('seeker-1#req-1#donor-1')
+    expect(dto.messageId).toBe('2026-06-26T00:00:00.000Z#01')
+    expect(dto.content).toBe('hello')
+  })
+})
+
+describe('ChatConnectionModel access patterns', () => {
+  const model = new ChatConnectionModel()
+  const baseDto: ChatConnectionDTO = {
+    connectionId: 'conn-1',
+    userId: 'user-1',
+    createdAt: '2026-06-26T00:00:00.000Z'
+  }
+
+  test('keys by connectionId (deletable with only connectionId) and indexes userId on GSI1', () => {
+    const fields = model.fromDto(baseDto)
+
+    expect(fields.PK).toBe('CONNECTION#conn-1')
+    expect(fields.SK).toBe('CONNECTION#conn-1')
+    expect(fields.GSI1PK).toBe('CHATUSER#user-1')
+    expect(fields.GSI1SK).toBe('CONNECTION#conn-1')
+  })
+
+  test('groups a user\'s multiple connections under one GSI1 partition for fanout', () => {
+    const conn1 = model.fromDto(baseDto)
+    const conn2 = model.fromDto({ ...baseDto, connectionId: 'conn-2' })
+
+    expect(conn1.GSI1PK).toBe(conn2.GSI1PK)
+    expect(conn1.PK).not.toBe(conn2.PK)
+  })
+
+  test('exposes GSI1 in the index definitions', () => {
+    expect(model.getIndex('GSI', 'GSI1')).toEqual({ partitionKey: 'GSI1PK', sortKey: 'GSI1SK' })
+  })
+
+  test('round-trips connectionId and userId', () => {
+    const dto = model.toDto(model.fromDto(baseDto))
+
+    expect(dto.connectionId).toBe('conn-1')
+    expect(dto.userId).toBe('user-1')
+  })
+})

--- a/core/services/aws/tests/dbModels/ChatModels.test.ts
+++ b/core/services/aws/tests/dbModels/ChatModels.test.ts
@@ -67,6 +67,14 @@ describe('ChatChannelModel keys (per-request channel query)', () => {
       donorId: 'd'
     })
   })
+
+  test('parseChannelId tolerates a # in the trailing donorId component', () => {
+    expect(parseChannelId('seeker-1#req-1#donor#weird')).toEqual({
+      seekerId: 'seeker-1',
+      requestPostId: 'req-1',
+      donorId: 'donor#weird'
+    })
+  })
 })
 
 describe('ChatMembershipModel keys (per-user membership query)', () => {

--- a/iac/terraform/aws/chat/data.tf
+++ b/iac/terraform/aws/chat/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/iac/terraform/aws/chat/lambdas.tf
+++ b/iac/terraform/aws/chat/lambdas.tf
@@ -76,6 +76,45 @@ locals {
       env_variables = {
         DYNAMODB_TABLE_NAME = local.table_name
       }
+    },
+    chat-list-channels = {
+      name                       = "chat-list-channels"
+      handler                    = "chatListChannels.default"
+      js_file_name               = "chatListChannels.js"
+      invocation_arn_placeholder = "CHAT_LIST_CHANNELS_INVOCATION_ARN"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_create_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    },
+    chat-get-history = {
+      name                       = "chat-get-history"
+      handler                    = "chatGetHistory.default"
+      js_file_name               = "chatGetHistory.js"
+      invocation_arn_placeholder = "CHAT_GET_HISTORY_INVOCATION_ARN"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_create_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    },
+    chat-mark-read = {
+      name                       = "chat-mark-read"
+      handler                    = "chatMarkRead.default"
+      js_file_name               = "chatMarkRead.js"
+      invocation_arn_placeholder = "CHAT_MARK_READ_INVOCATION_ARN"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_update_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
     }
   }
 }

--- a/iac/terraform/aws/chat/lambdas.tf
+++ b/iac/terraform/aws/chat/lambdas.tf
@@ -1,0 +1,81 @@
+locals {
+  table_name = split("/", var.dynamodb_table_arn)[1]
+
+  lambda_options = {
+    chat-connect = {
+      name         = "chat-connect"
+      handler      = "chatConnect.default"
+      js_file_name = "chatConnect.js"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_create_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    },
+    chat-disconnect = {
+      name         = "chat-disconnect"
+      handler      = "chatDisconnect.default"
+      js_file_name = "chatDisconnect.js"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_update_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    },
+    chat-send-message = {
+      name         = "chat-send-message"
+      handler      = "chatSendMessage.default"
+      js_file_name = "chatSendMessage.js"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_create_policy,
+        local.policies.dynamodb_update_policy,
+        local.policies.sqs_policy,
+        local.policies.manage_connections_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME    = local.table_name
+        NOTIFICATION_QUEUE_URL = var.push_notification_queue.url
+      }
+    },
+    chat-authorizer = {
+      name         = "chat-authorizer"
+      handler      = "chatConnectAuthorizer.default"
+      js_file_name = "chatConnectAuthorizer.js"
+      statement    = local.policies.common_policies
+      env_variables = {
+        COGNITO_USER_POOL_ID = var.cognito_user_pool_id
+        COGNITO_CLIENT_ID    = var.cognito_app_client_id
+      }
+    },
+    chat-channel-creator = {
+      name         = "chat-channel-creator"
+      handler      = "chatChannelCreator.default"
+      js_file_name = "chatChannelCreator.js"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_create_policy,
+        local.policies.dynamodb_update_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    },
+    chat-channel-locker = {
+      name         = "chat-channel-locker"
+      handler      = "chatChannelLocker.default"
+      js_file_name = "chatChannelLocker.js"
+      statement = concat(
+        local.policies.common_policies,
+        local.policies.dynamodb_update_policy
+      )
+      env_variables = {
+        DYNAMODB_TABLE_NAME = local.table_name
+      }
+    }
+  }
+}

--- a/iac/terraform/aws/chat/modules.tf
+++ b/iac/terraform/aws/chat/modules.tf
@@ -1,0 +1,6 @@
+module "lambda" {
+  for_each      = local.lambda_options
+  source        = "./../lambda"
+  environment   = var.environment
+  lambda_option = each.value
+}

--- a/iac/terraform/aws/chat/outputs.tf
+++ b/iac/terraform/aws/chat/outputs.tf
@@ -9,3 +9,17 @@ output "chat_websocket_endpoint" {
 output "chat_websocket_stage_name" {
   value = aws_apigatewayv2_stage.chat.name
 }
+
+# Only the REST chat lambdas (those with an invocation_arn_placeholder) are exposed to the
+# REST API Gateway: they need an invoke permission and an OpenAPI integration ARN substitution.
+# The WS/pipe lambdas are wired by the WebSocket API and EventBridge pipes, not here.
+output "lambda_metadata" {
+  value = [
+    for key, option in local.lambda_options : {
+      lambda_function_name       = module.lambda[key].lambda_function_name
+      lambda_invoke_arn          = module.lambda[key].lambda_invoke_arn
+      invocation_arn_placeholder = option.invocation_arn_placeholder
+    }
+    if try(option.invocation_arn_placeholder, null) != null
+  ]
+}

--- a/iac/terraform/aws/chat/outputs.tf
+++ b/iac/terraform/aws/chat/outputs.tf
@@ -1,0 +1,11 @@
+output "chat_websocket_api_id" {
+  value = aws_apigatewayv2_api.chat.id
+}
+
+output "chat_websocket_endpoint" {
+  value = aws_apigatewayv2_stage.chat.invoke_url
+}
+
+output "chat_websocket_stage_name" {
+  value = aws_apigatewayv2_stage.chat.name
+}

--- a/iac/terraform/aws/chat/pipes.tf
+++ b/iac/terraform/aws/chat/pipes.tf
@@ -1,0 +1,187 @@
+# EventBridge pipes drive the chat channel lifecycle off the DynamoDB stream, mirroring the
+# donation accept/ignore pipes: INSERT of an ACCEPTED# record opens a channel, REMOVE locks it.
+
+data "aws_iam_policy_document" "chat_pipe_assume_role" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["pipes.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "chat_pipe_role" {
+  name               = "${var.environment}-chat-pipe-role"
+  assume_role_policy = data.aws_iam_policy_document.chat_pipe_assume_role.json
+}
+
+data "aws_iam_policy_document" "chat_pipe_policy_doc" {
+  statement {
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeStream",
+      "dynamodb:GetRecords",
+      "dynamodb:GetShardIterator",
+      "dynamodb:ListStreams"
+    ]
+    resources = [var.dynamodb_table_stream_arn]
+  }
+  statement {
+    effect  = "Allow"
+    actions = ["lambda:InvokeFunction"]
+    resources = [
+      module.lambda["chat-channel-creator"].lambda_arn,
+      module.lambda["chat-channel-locker"].lambda_arn
+    ]
+  }
+  statement {
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [
+      "${aws_cloudwatch_log_group.chat_channel_create_pipe.arn}:*",
+      "${aws_cloudwatch_log_group.chat_channel_lock_pipe.arn}:*"
+    ]
+  }
+}
+
+resource "aws_iam_role_policy" "chat_pipe_policy" {
+  name   = "${var.environment}-chat-pipe-policy"
+  role   = aws_iam_role.chat_pipe_role.id
+  policy = data.aws_iam_policy_document.chat_pipe_policy_doc.json
+}
+
+resource "aws_cloudwatch_log_group" "chat_channel_create_pipe" {
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
+  name              = "/aws/vendedlogs/pipes/${var.environment}-chat-channel-create-pipe"
+  retention_in_days = 30
+}
+
+resource "aws_cloudwatch_log_group" "chat_channel_lock_pipe" {
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
+  name              = "/aws/vendedlogs/pipes/${var.environment}-chat-channel-lock-pipe"
+  retention_in_days = 30
+}
+
+# Creation pipe: INSERT of an ACCEPTED# record -> open (or re-open) the donor's chat channel.
+resource "aws_pipes_pipe" "chat_channel_create_pipe" {
+  name     = "${var.environment}-chat-channel-create-pipe"
+  role_arn = aws_iam_role.chat_pipe_role.arn
+  source   = var.dynamodb_table_stream_arn
+  target   = module.lambda["chat-channel-creator"].lambda_arn
+
+  source_parameters {
+    dynamodb_stream_parameters {
+      starting_position             = "LATEST"
+      batch_size                    = 1
+      maximum_record_age_in_seconds = -1
+    }
+
+    filter_criteria {
+      filter {
+        pattern = jsonencode({
+          "eventName" : ["INSERT"],
+          "dynamodb" : {
+            "NewImage" : {
+              "PK" : { "S" : [{ "prefix" : "BLOOD_REQ#" }] },
+              "SK" : { "S" : [{ "prefix" : "ACCEPTED#" }] }
+            }
+          }
+        })
+      }
+    }
+  }
+
+  target_parameters {
+    input_template = <<EOF
+{
+  "PK": "<$.dynamodb.NewImage.PK.S>",
+  "SK": "<$.dynamodb.NewImage.SK.S>",
+  "createdAt": "<$.dynamodb.NewImage.createdAt.S>"
+}
+EOF
+  }
+
+  log_configuration {
+    include_execution_data = ["ALL"]
+    level                  = "INFO"
+    cloudwatch_logs_log_destination {
+      log_group_arn = aws_cloudwatch_log_group.chat_channel_create_pipe.arn
+    }
+  }
+
+  depends_on = [aws_iam_role_policy.chat_pipe_policy]
+}
+
+# Lock pipe: REMOVE of an ACCEPTED# record (IGNORED) -> lock the donor's chat channel.
+resource "aws_pipes_pipe" "chat_channel_lock_pipe" {
+  name     = "${var.environment}-chat-channel-lock-pipe"
+  role_arn = aws_iam_role.chat_pipe_role.arn
+  source   = var.dynamodb_table_stream_arn
+  target   = module.lambda["chat-channel-locker"].lambda_arn
+
+  source_parameters {
+    dynamodb_stream_parameters {
+      starting_position             = "LATEST"
+      batch_size                    = 1
+      maximum_record_age_in_seconds = -1
+    }
+
+    filter_criteria {
+      filter {
+        pattern = jsonencode({
+          "eventName" : ["REMOVE"],
+          "dynamodb" : {
+            "OldImage" : {
+              "PK" : { "S" : [{ "prefix" : "BLOOD_REQ#" }] },
+              "SK" : { "S" : [{ "prefix" : "ACCEPTED#" }] }
+            }
+          }
+        })
+      }
+    }
+  }
+
+  target_parameters {
+    input_template = <<EOF
+{
+  "PK": "<$.dynamodb.OldImage.PK.S>",
+  "SK": "<$.dynamodb.OldImage.SK.S>",
+  "createdAt": "<$.dynamodb.OldImage.createdAt.S>"
+}
+EOF
+  }
+
+  log_configuration {
+    include_execution_data = ["ALL"]
+    level                  = "INFO"
+    cloudwatch_logs_log_destination {
+      log_group_arn = aws_cloudwatch_log_group.chat_channel_lock_pipe.arn
+    }
+  }
+
+  depends_on = [aws_iam_role_policy.chat_pipe_policy]
+}
+
+resource "aws_lambda_permission" "allow_create_pipe_invoke_creator" {
+  statement_id  = "AllowExecutionFromChatCreatePipe"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-channel-creator"].lambda_function_name
+  principal     = "pipes.amazonaws.com"
+  source_arn    = aws_pipes_pipe.chat_channel_create_pipe.arn
+}
+
+resource "aws_lambda_permission" "allow_lock_pipe_invoke_locker" {
+  statement_id  = "AllowExecutionFromChatLockPipe"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-channel-locker"].lambda_function_name
+  principal     = "pipes.amazonaws.com"
+  source_arn    = aws_pipes_pipe.chat_channel_lock_pipe.arn
+}

--- a/iac/terraform/aws/chat/policies.tf
+++ b/iac/terraform/aws/chat/policies.tf
@@ -1,0 +1,65 @@
+locals {
+  policies = {
+    common_policies = [
+      {
+        sid = "LogPolicy"
+        actions = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        resources = [
+          "arn:aws:logs:*:*:*"
+        ]
+      }
+    ],
+    dynamodb_create_policy = [
+      {
+        sid = "DynamodbCreatePolicy"
+        actions = [
+          "dynamodb:PutItem",
+          "dynamodb:GetItem",
+          "dynamodb:Query"
+        ]
+        resources = [var.dynamodb_table_arn]
+      }
+    ],
+    dynamodb_update_policy = [
+      {
+        sid = "DynamodbUpdatePolicy"
+        actions = [
+          "dynamodb:UpdateItem",
+          "dynamodb:GetItem",
+          "dynamodb:Query",
+          "dynamodb:DeleteItem"
+        ]
+        resources = [
+          var.dynamodb_table_arn,
+          "${var.dynamodb_table_arn}/index/GSI1"
+        ]
+      }
+    ],
+    sqs_policy = [
+      {
+        sid = "SqsPolicy"
+        actions = [
+          "sqs:SendMessage"
+        ]
+        resources = [var.push_notification_queue.arn]
+      }
+    ],
+    # Lets the fanout (sendMessage) lambda post messages back to live WebSocket connections.
+    manage_connections_policy = [
+      {
+        sid = "ManageConnectionsPolicy"
+        actions = [
+          "execute-api:ManageConnections"
+        ]
+        resources = [
+          "${aws_apigatewayv2_api.chat.execution_arn}/*"
+        ]
+      }
+    ]
+  }
+}

--- a/iac/terraform/aws/chat/variables.tf
+++ b/iac/terraform/aws/chat/variables.tf
@@ -1,0 +1,28 @@
+variable "environment" {
+  type        = string
+  description = "Deployment environment"
+}
+
+variable "dynamodb_table_arn" {
+  type        = string
+  description = "ARN of the DynamoDB table"
+}
+
+variable "dynamodb_table_stream_arn" {
+  type        = string
+  description = "ARN of the DynamoDB table stream feeding the chat channel pipes"
+}
+
+variable "push_notification_queue" {
+  description = "Push notification SQS queue (for offline CHAT_MESSAGE fallback)"
+}
+
+variable "cognito_user_pool_id" {
+  type        = string
+  description = "Cognito user pool id the $connect authorizer validates JWTs against"
+}
+
+variable "cognito_app_client_id" {
+  type        = string
+  description = "Cognito app client id the $connect authorizer validates JWTs against"
+}

--- a/iac/terraform/aws/chat/websocket.tf
+++ b/iac/terraform/aws/chat/websocket.tf
@@ -52,12 +52,16 @@ resource "aws_apigatewayv2_route" "connect" {
 }
 
 resource "aws_apigatewayv2_route" "disconnect" {
+  # checkov:skip=CKV_AWS_309: Authorization is enforced once at $connect via the Cognito custom
+  # authorizer; WebSocket APIs do not re-authorize per-message routes, which inherit the connection.
   api_id    = aws_apigatewayv2_api.chat.id
   route_key = "$disconnect"
   target    = "integrations/${aws_apigatewayv2_integration.disconnect.id}"
 }
 
 resource "aws_apigatewayv2_route" "send_message" {
+  # checkov:skip=CKV_AWS_309: Authorization is enforced once at $connect via the Cognito custom
+  # authorizer; WebSocket APIs do not re-authorize per-message routes, which inherit the connection.
   api_id    = aws_apigatewayv2_api.chat.id
   route_key = "sendMessage"
   target    = "integrations/${aws_apigatewayv2_integration.send_message.id}"
@@ -91,10 +95,32 @@ resource "aws_apigatewayv2_deployment" "chat" {
   ]
 }
 
+resource "aws_cloudwatch_log_group" "chat_websocket_access" {
+  #checkov:skip=CKV_AWS_338: "Ensure CloudWatch log groups retains logs for at least 1 year"
+  #checkov:skip=CKV_AWS_158: "Ensure that CloudWatch Log Group is encrypted by KMS"
+  name              = "/aws/apigateway/${var.environment}-chat-websocket"
+  retention_in_days = 60
+}
+
 resource "aws_apigatewayv2_stage" "chat" {
+  # checkov:skip=CKV2_AWS_51: Client certificate auth verifies API Gateway to an HTTP backend; the
+  # chat integrations are Lambda AWS_PROXY, so mutual TLS to a backend is not applicable.
   api_id        = aws_apigatewayv2_api.chat.id
   name          = var.environment
   deployment_id = aws_apigatewayv2_deployment.chat.id
+
+  access_log_settings {
+    destination_arn = aws_cloudwatch_log_group.chat_websocket_access.arn
+    format = jsonencode({
+      requestId        = "$context.requestId"
+      connectionId     = "$context.connectionId"
+      routeKey         = "$context.routeKey"
+      eventType        = "$context.eventType"
+      status           = "$context.status"
+      requestTime      = "$context.requestTime"
+      integrationError = "$context.integrationErrorMessage"
+    })
+  }
 }
 
 # --- Permissions for API Gateway to invoke the lambdas ---

--- a/iac/terraform/aws/chat/websocket.tf
+++ b/iac/terraform/aws/chat/websocket.tf
@@ -1,0 +1,132 @@
+resource "aws_apigatewayv2_api" "chat" {
+  name                       = "${var.environment}-chat-websocket"
+  protocol_type              = "WEBSOCKET"
+  route_selection_expression = "$request.body.action"
+}
+
+# --- Integrations (AWS_PROXY to the WebSocket lambdas) ---
+
+resource "aws_apigatewayv2_integration" "connect" {
+  api_id             = aws_apigatewayv2_api.chat.id
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+  integration_uri    = module.lambda["chat-connect"].lambda_invoke_arn
+}
+
+resource "aws_apigatewayv2_integration" "disconnect" {
+  api_id             = aws_apigatewayv2_api.chat.id
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+  integration_uri    = module.lambda["chat-disconnect"].lambda_invoke_arn
+}
+
+resource "aws_apigatewayv2_integration" "send_message" {
+  api_id             = aws_apigatewayv2_api.chat.id
+  integration_type   = "AWS_PROXY"
+  integration_method = "POST"
+  integration_uri    = module.lambda["chat-send-message"].lambda_invoke_arn
+}
+
+# --- Cognito JWT lambda authorizer (REQUEST type; WebSocket has no native JWT authorizer) ---
+
+resource "aws_apigatewayv2_authorizer" "chat_connect" {
+  api_id          = aws_apigatewayv2_api.chat.id
+  authorizer_type = "REQUEST"
+  authorizer_uri  = module.lambda["chat-authorizer"].lambda_invoke_arn
+  # Token carried as a query string param: WebSocket clients cannot set headers on $connect.
+  identity_sources = ["route.request.querystring.token"]
+  name             = "${var.environment}-chat-connect-authorizer"
+  # 0 disables result caching, so every $connect re-validates the JWT (catches expired/revoked
+  # tokens immediately; $connect is infrequent so the per-connection cost is negligible).
+  authorizer_result_ttl_in_seconds = 0
+}
+
+# --- Routes ---
+
+resource "aws_apigatewayv2_route" "connect" {
+  api_id             = aws_apigatewayv2_api.chat.id
+  route_key          = "$connect"
+  authorization_type = "CUSTOM"
+  authorizer_id      = aws_apigatewayv2_authorizer.chat_connect.id
+  target             = "integrations/${aws_apigatewayv2_integration.connect.id}"
+}
+
+resource "aws_apigatewayv2_route" "disconnect" {
+  api_id    = aws_apigatewayv2_api.chat.id
+  route_key = "$disconnect"
+  target    = "integrations/${aws_apigatewayv2_integration.disconnect.id}"
+}
+
+resource "aws_apigatewayv2_route" "send_message" {
+  api_id    = aws_apigatewayv2_api.chat.id
+  route_key = "sendMessage"
+  target    = "integrations/${aws_apigatewayv2_integration.send_message.id}"
+}
+
+# --- Deployment + stage (WebSocket APIs use explicit deployments, not auto_deploy) ---
+
+resource "aws_apigatewayv2_deployment" "chat" {
+  api_id = aws_apigatewayv2_api.chat.id
+
+  triggers = {
+    redeployment = sha1(jsonencode([
+      aws_apigatewayv2_route.connect.id,
+      aws_apigatewayv2_route.disconnect.id,
+      aws_apigatewayv2_route.send_message.id,
+      aws_apigatewayv2_integration.connect.id,
+      aws_apigatewayv2_integration.disconnect.id,
+      aws_apigatewayv2_integration.send_message.id,
+      aws_apigatewayv2_authorizer.chat_connect.id
+    ]))
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [
+    aws_apigatewayv2_route.connect,
+    aws_apigatewayv2_route.disconnect,
+    aws_apigatewayv2_route.send_message
+  ]
+}
+
+resource "aws_apigatewayv2_stage" "chat" {
+  api_id        = aws_apigatewayv2_api.chat.id
+  name          = var.environment
+  deployment_id = aws_apigatewayv2_deployment.chat.id
+}
+
+# --- Permissions for API Gateway to invoke the lambdas ---
+
+resource "aws_lambda_permission" "connect" {
+  statement_id  = "AllowWebSocketInvokeConnect"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-connect"].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.chat.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "disconnect" {
+  statement_id  = "AllowWebSocketInvokeDisconnect"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-disconnect"].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.chat.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "send_message" {
+  statement_id  = "AllowWebSocketInvokeSendMessage"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-send-message"].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.chat.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "authorizer" {
+  statement_id  = "AllowWebSocketInvokeAuthorizer"
+  action        = "lambda:InvokeFunction"
+  function_name = module.lambda["chat-authorizer"].lambda_function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.chat.execution_arn}/authorizers/*"
+}

--- a/iac/terraform/aws/dynamodb/dynamodb.tf
+++ b/iac/terraform/aws/dynamodb/dynamodb.tf
@@ -8,6 +8,13 @@ resource "aws_dynamodb_table" "blood_connect_data" {
   stream_enabled   = true
   stream_view_type = "NEW_AND_OLD_IMAGES"
 
+  # 90-day purge of chat messages and rate-limit counter items (which carry a `ttl` epoch-seconds
+  # attribute). No new GSI is required: chat channel listing uses base-table membership items.
+  ttl {
+    attribute_name = "ttl"
+    enabled        = true
+  }
+
   attribute {
     name = "PK"
     type = "S"

--- a/iac/terraform/aws/local.tf
+++ b/iac/terraform/aws/local.tf
@@ -6,7 +6,8 @@ locals {
     module.notification.lambda_metadata,
     module.user.lambda_metadata,
     module.logger.lambda_metadata,
-    module.maps.lambda_metadata
+    module.maps.lambda_metadata,
+    module.chat.lambda_metadata
   )
 
   all_lambda_invoke_arns = merge({

--- a/iac/terraform/aws/modules.tf
+++ b/iac/terraform/aws/modules.tf
@@ -95,10 +95,20 @@ module "eventbridge" {
 }
 
 module "notification" {
-  source                  = "./notification"
-  environment             = var.environment
-  dynamodb_table_arn      = module.database.dynamodb_table_arn
-  firebase_token_s3_url   = var.firebase_token_s3_url
+  source                = "./notification"
+  environment           = var.environment
+  dynamodb_table_arn    = module.database.dynamodb_table_arn
+  firebase_token_s3_url = var.firebase_token_s3_url
+}
+
+module "chat" {
+  source                    = "./chat"
+  environment               = var.environment
+  dynamodb_table_arn        = module.database.dynamodb_table_arn
+  dynamodb_table_stream_arn = module.database.dynamodb_table_stream_arn
+  push_notification_queue   = module.notification.push_notification_queue
+  cognito_user_pool_id      = module.cognito.user_pool_id
+  cognito_app_client_id     = module.cognito.user_pool_client_id
 }
 
 module "maps" {

--- a/openapi/components/schemas/chat/get-history.json
+++ b/openapi/components/schemas/chat/get-history.json
@@ -1,0 +1,27 @@
+{
+  "GetChatHistoryModel": {
+    "type": "object",
+    "required": [
+      "channelId"
+    ],
+    "properties": {
+      "channelId": {
+        "type": "string",
+        "minLength": 1
+      },
+      "limit": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 100
+      },
+      "exclusiveStartKey": {
+        "type": "object",
+        "additionalProperties": true
+      }
+    },
+    "example": {
+      "channelId": "123abc#post01110#456def",
+      "limit": 20
+    }
+  }
+}

--- a/openapi/components/schemas/chat/mark-read.json
+++ b/openapi/components/schemas/chat/mark-read.json
@@ -1,0 +1,17 @@
+{
+  "MarkChatReadModel": {
+    "type": "object",
+    "required": [
+      "channelId"
+    ],
+    "properties": {
+      "channelId": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "example": {
+      "channelId": "123abc#post01110#456def"
+    }
+  }
+}

--- a/openapi/integration/aws/chat/get-channels.json
+++ b/openapi/integration/aws/chat/get-channels.json
@@ -1,0 +1,22 @@
+{
+  "type": "aws",
+  "httpMethod": "POST",
+  "uri": "${CHAT_LIST_CHANNELS_INVOCATION_ARN}",
+  "requestTemplates": {
+    "application/json": "#importVtl chat/vtl/requestTemplates/get-channels.vtl"
+  },
+  "responses": {
+    "default": {
+      "statusCode": "200",
+      "responseParameters": {
+        "method.response.header.Access-Control-Allow-Methods": "'GET'",
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+        "method.response.header.Access-Control-Allow-Origin": "'*'"
+      },
+      "responseTemplates": {
+        "application/json": "#importVtl chat/vtl/responseTemplates/get-channels.vtl"
+      }
+    }
+  },
+  "passthroughBehavior": "never"
+}

--- a/openapi/integration/aws/chat/patch-read.json
+++ b/openapi/integration/aws/chat/patch-read.json
@@ -1,0 +1,22 @@
+{
+  "type": "aws",
+  "httpMethod": "POST",
+  "uri": "${CHAT_MARK_READ_INVOCATION_ARN}",
+  "requestTemplates": {
+    "application/json": "#importVtl chat/vtl/requestTemplates/patch-read.vtl"
+  },
+  "responses": {
+    "default": {
+      "statusCode": "200",
+      "responseParameters": {
+        "method.response.header.Access-Control-Allow-Methods": "'PATCH'",
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+        "method.response.header.Access-Control-Allow-Origin": "'*'"
+      },
+      "responseTemplates": {
+        "application/json": "#importVtl chat/vtl/responseTemplates/patch-read.vtl"
+      }
+    }
+  },
+  "passthroughBehavior": "never"
+}

--- a/openapi/integration/aws/chat/post-history.json
+++ b/openapi/integration/aws/chat/post-history.json
@@ -1,0 +1,22 @@
+{
+  "type": "aws",
+  "httpMethod": "POST",
+  "uri": "${CHAT_GET_HISTORY_INVOCATION_ARN}",
+  "requestTemplates": {
+    "application/json": "#importVtl chat/vtl/requestTemplates/post-history.vtl"
+  },
+  "responses": {
+    "default": {
+      "statusCode": "200",
+      "responseParameters": {
+        "method.response.header.Access-Control-Allow-Methods": "'POST'",
+        "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+        "method.response.header.Access-Control-Allow-Origin": "'*'"
+      },
+      "responseTemplates": {
+        "application/json": "#importVtl chat/vtl/responseTemplates/post-history.vtl"
+      }
+    }
+  },
+  "passthroughBehavior": "never"
+}

--- a/openapi/integration/aws/chat/vtl/requestTemplates/get-channels.vtl
+++ b/openapi/integration/aws/chat/vtl/requestTemplates/get-channels.vtl
@@ -1,0 +1,5 @@
+{
+  "userId": "$context.authorizer.claims['custom:userId']",
+  "cloudFrontRequestId": "$input.params('X-Amz-Cf-Id')",
+  "apiGwRequestId": "$context.requestId"
+}

--- a/openapi/integration/aws/chat/vtl/requestTemplates/patch-read.vtl
+++ b/openapi/integration/aws/chat/vtl/requestTemplates/patch-read.vtl
@@ -1,0 +1,7 @@
+#set($inputRoot = $input.path('$'))
+{
+  "userId": "$context.authorizer.claims['custom:userId']",
+  "cloudFrontRequestId": "$input.params('X-Amz-Cf-Id')",
+  "apiGwRequestId": "$context.requestId",
+  "channelId": "$inputRoot.channelId"
+}

--- a/openapi/integration/aws/chat/vtl/requestTemplates/post-history.vtl
+++ b/openapi/integration/aws/chat/vtl/requestTemplates/post-history.vtl
@@ -1,0 +1,9 @@
+#set($inputRoot = $input.path('$'))
+{
+  "userId": "$context.authorizer.claims['custom:userId']",
+  "cloudFrontRequestId": "$input.params('X-Amz-Cf-Id')",
+  "apiGwRequestId": "$context.requestId",
+  "channelId": "$inputRoot.channelId"#if($inputRoot.limit),
+  "limit": $inputRoot.limit#end#if($inputRoot.exclusiveStartKey),
+  "exclusiveStartKey": $input.json('$.exclusiveStartKey')#end
+}

--- a/openapi/integration/aws/chat/vtl/responseTemplates/get-channels.vtl
+++ b/openapi/integration/aws/chat/vtl/responseTemplates/get-channels.vtl
@@ -1,0 +1,3 @@
+#set($inputRoot = $input.path('$'))
+#set($context.responseOverride.status = $inputRoot.statusCode)
+$inputRoot.body

--- a/openapi/integration/aws/chat/vtl/responseTemplates/patch-read.vtl
+++ b/openapi/integration/aws/chat/vtl/responseTemplates/patch-read.vtl
@@ -1,0 +1,3 @@
+#set($inputRoot = $input.path('$'))
+#set($context.responseOverride.status = $inputRoot.statusCode)
+$inputRoot.body

--- a/openapi/integration/aws/chat/vtl/responseTemplates/post-history.vtl
+++ b/openapi/integration/aws/chat/vtl/responseTemplates/post-history.vtl
@@ -1,0 +1,3 @@
+#set($inputRoot = $input.path('$'))
+#set($context.responseOverride.status = $inputRoot.statusCode)
+$inputRoot.body

--- a/openapi/paths/chat/channels.json
+++ b/openapi/paths/chat/channels.json
@@ -1,0 +1,44 @@
+{
+  "get": {
+    "operationId": "ListChatChannels",
+    "description": "List the authenticated user's chat channels with last-message and last-read markers",
+    "tags": [
+      "bloodconnect-chat"
+    ],
+    "responses": {
+      "200": {
+        "description": "200 response",
+        "headers": {
+          "Access-Control-Allow-Origin": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Methods": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Headers": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {}
+      }
+    },
+    "x-amazon-apigateway-request-validator": "ValidateBodyAndQuery",
+    "x-amazon-apigateway-integration": {
+      "$ref": "./../../integration/aws/chat/get-channels.json"
+    },
+    "security": [
+      {
+        "CognitoAuthorizer": []
+      }
+    ]
+  },
+  "options": {
+    "$ref": "./../cors-options.json"
+  }
+}

--- a/openapi/paths/chat/history.json
+++ b/openapi/paths/chat/history.json
@@ -1,0 +1,53 @@
+{
+  "post": {
+    "operationId": "GetChatHistory",
+    "description": "Get a newest-first, paginated page of a chat channel's messages (participant-only)",
+    "tags": [
+      "bloodconnect-chat"
+    ],
+    "requestBody": {
+      "content": {
+        "application/json": {
+          "schema": {
+            "$ref": "./../../components/schemas/chat/get-history.json#/GetChatHistoryModel"
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "200 response",
+        "headers": {
+          "Access-Control-Allow-Origin": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Methods": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Headers": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {}
+      }
+    },
+    "x-amazon-apigateway-request-validator": "ValidateBodyAndQuery",
+    "x-amazon-apigateway-integration": {
+      "$ref": "./../../integration/aws/chat/post-history.json"
+    },
+    "security": [
+      {
+        "CognitoAuthorizer": []
+      }
+    ]
+  },
+  "options": {
+    "$ref": "./../cors-options.json"
+  }
+}

--- a/openapi/paths/chat/read.json
+++ b/openapi/paths/chat/read.json
@@ -1,0 +1,53 @@
+{
+  "patch": {
+    "operationId": "MarkChatRead",
+    "description": "Mark the authenticated user's last-read marker on a chat channel (participant-only)",
+    "tags": [
+      "bloodconnect-chat"
+    ],
+    "requestBody": {
+      "content": {
+        "application/json": {
+          "schema": {
+            "$ref": "./../../components/schemas/chat/mark-read.json#/MarkChatReadModel"
+          }
+        }
+      }
+    },
+    "responses": {
+      "200": {
+        "description": "200 response",
+        "headers": {
+          "Access-Control-Allow-Origin": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Methods": {
+            "schema": {
+              "type": "string"
+            }
+          },
+          "Access-Control-Allow-Headers": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {}
+      }
+    },
+    "x-amazon-apigateway-request-validator": "ValidateBodyAndQuery",
+    "x-amazon-apigateway-integration": {
+      "$ref": "./../../integration/aws/chat/patch-read.json"
+    },
+    "security": [
+      {
+        "CognitoAuthorizer": []
+      }
+    ]
+  },
+  "options": {
+    "$ref": "./../cors-options.json"
+  }
+}

--- a/openapi/versions/v1.json
+++ b/openapi/versions/v1.json
@@ -14,6 +14,10 @@
       "description": "Push notification module of BloodConnect"
     },
     {
+      "name": "bloodconnect-chat",
+      "description": "In-app chat module of BloodConnect"
+    },
+    {
       "name": "cors-options",
       "description": "API Endpoints for BloodConnect cors options"
     }
@@ -67,6 +71,15 @@
     },
     "/notification/register": {
       "$ref": "./../paths/notification/register.json"
+    },
+    "/chat/channels": {
+      "$ref": "./../paths/chat/channels.json"
+    },
+    "/chat/history": {
+      "$ref": "./../paths/chat/history.json"
+    },
+    "/chat/read": {
+      "$ref": "./../paths/chat/read.json"
     },
     "/maps/place/autocomplete/json": {
       "$ref": "./../paths/maps/get-place-auto-complete.json"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
       }
     },
     "clients/mobile": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dependencies": {
         "@aws-amplify/react-native": "^1.1.10",
         "@aws-amplify/rtn-web-browser": "^1.1.4",
@@ -116,6 +116,7 @@
         "@aws-amplify/ui-react": "^6.9.4",
         "@aws-sdk/client-dynamodb": "^3.808.0",
         "@aws-sdk/client-s3": "^3.772.0",
+        "@aws-sdk/util-dynamodb": "^3.808.0",
         "@uiw/react-json-view": "^2.0.0-alpha.32",
         "aws-amplify": "^6.13.6",
         "bootstrap": "^5.3.6",
@@ -482,6 +483,7 @@
       "version": "0.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@aws-sdk/client-apigatewaymanagementapi": "^3.651.1",
         "@aws-sdk/client-cognito-identity-provider": "^3.651.1",
         "@aws-sdk/client-dynamodb": "^3.651.1",
         "@aws-sdk/client-s3": "^3.723.0",
@@ -490,6 +492,7 @@
         "@aws-sdk/client-sns": "^3.682.0",
         "@aws-sdk/client-sqs": "^3.651.1",
         "@aws-sdk/lib-dynamodb": "^3.651.1",
+        "aws-jwt-verify": "^4.0.1",
         "aws-lambda": "^1.0.7"
       },
       "devDependencies": {
@@ -1647,6 +1650,265 @@
         "@aws-sdk/types": "^3.222.0",
         "@smithy/util-utf8": "^2.0.0",
         "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi": {
+      "version": "3.1075.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-apigatewaymanagementapi/-/client-apigatewaymanagementapi-3.1075.0.tgz",
+      "integrity": "sha512-mK5VAguQEvNmIDUUaVdI1iLCXBbZptNdifPuhj9CzpILBSyxXSUutfG82+nfWV8g+IPafUCjcwrC47zXIGS6qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-node": "^3.972.58",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.49.tgz",
+      "integrity": "sha512-liB3yQNHCM9k/gu/w36XHMKPluT7HTlnGUhRbBGSISDQkcr/Sy1zsZabiuvQj8WG5yW573u9RehrBvvnIQ9OEQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.972.51",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.51.tgz",
+      "integrity": "sha512-XET0H2oofciJ5lMRWNIvRjAP7Q3wv2XT+JtJJEdhPWUMwe3TvQ9qcxonpu7vXmNngncvFpi4E2It+Tamas/naA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.972.56",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.56.tgz",
+      "integrity": "sha512-IAmc61hbgQiHht9U3x0tnRwz0lzdwOwD/i9voRgdJrKamF+JtmrBOsW9GwB7mfFonNWOWL4qARWYrF8veEMe3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-login": "^3.972.55",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.972.58",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.58.tgz",
+      "integrity": "sha512-OyCLVmSI7pZO8hxwNVX6pXhTVlJqRBTp+ijdEfJSUj0RyjHnF602OfAarOzGq6wkGodeFkYBt8MmJ6A6ycRgWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "^3.972.49",
+        "@aws-sdk/credential-provider-http": "^3.972.51",
+        "@aws-sdk/credential-provider-ini": "^3.972.56",
+        "@aws-sdk/credential-provider-process": "^3.972.49",
+        "@aws-sdk/credential-provider-sso": "^3.972.55",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.55",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/credential-provider-imds": "^4.3.7",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.49.tgz",
+      "integrity": "sha512-C8h36lBuC/RnBSsjlO+dn6xZm3KbAl5vpJaVPAfQnMmz2/OISmKOc8XZcqMQgO2ADwBYNRMM6Kf3vz9G/TulMQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.55.tgz",
+      "integrity": "sha512-1FkOz74Ea5QGS9jtIoXp55T/IkSS3spv+nLTT07fRY/+T5xmEOqaYBVIaEmX4zTNvbV6g2lrtlaVKWEoNyJt3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/token-providers": "3.1074.0",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.55.tgz",
+      "integrity": "sha512-g2BoECD1q01kTPByi56+VLVvdWDzMkKIcr77qixpqH0okw2t0U5CoPv+6S8v/D1Y2Wa6QKKtn6XAtDzP+Kfpvg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/token-providers": {
+      "version": "3.1074.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1074.0.tgz",
+      "integrity": "sha512-pv80IzgGW4RnXWtft692chZOM9i6PhebVsLCcnaM4dBEPZva2fE6FXAHs76G7Rc7s3yGyX/68G0nZMrUy+Vmpg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-apigatewaymanagementapi/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity-provider": {
@@ -8153,6 +8415,113 @@
         "@smithy/types": "^4.5.0",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.55",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.55.tgz",
+      "integrity": "sha512-hBBkANo3cDn+h2qxxzER4a+J8JCO9o9Z/YYmU7iky6AcaarX5RRdRcHNC6SLdwY0vAXQygn6soUbDqPn3GghaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/nested-clients": "^3.997.23",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/core": {
+      "version": "3.974.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.23.tgz",
+      "integrity": "sha512-MiWR/uWjxjFXGzrE0Ghc5lWxUxzHsUWFhV+OX7M4cR9SrmrnZs6TXavnCWnzzdwJeFri34xQo81rvGNzK3c4BQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@aws-sdk/xml-builder": "^3.972.31",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/core": "^3.24.6",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.997.23",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.23.tgz",
+      "integrity": "sha512-gO93ZPsI2bxeFZD42f1/qjDw6FAZkNZcKRO94LIiT03fzOmcJ9e/tunxjVjA1Rl69ClmVJzz8H3G9CdKef10PA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.974.23",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.35",
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/core": "^3.24.6",
+        "@smithy/fetch-http-handler": "^5.4.6",
+        "@smithy/node-http-handler": "^4.7.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.996.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.35.tgz",
+      "integrity": "sha512-6L/VWs+Wch2stHemCGTmUNqKLMzURxQDK5boNG3Jn3kAOp71meDUuS5sbObpEvFxHDq0uWeSLFDNSYsjNt+Dlg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.13",
+        "@smithy/signature-v4": "^5.4.6",
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/types": {
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.13.tgz",
+      "integrity": "sha512-pEHZqRkAlHfnfAU9tK+WpKv/gBNjGJrHMgA3A0iYRGyswBS2t0pfez+lWlwktb3Bqa0ovh7w/QJTFwp3fDxLNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.31.tgz",
+      "integrity": "sha512-SzE4Pgyl+hDF+BuyuzxUSpwnuUu9lJuO1YGgteG89/4Qv0+2IQiVQqdbPV32IozLvXWQChPQcdkk/sKvb1QHiQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.3",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
@@ -15547,33 +15916,13 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.16.1",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.16.1.tgz",
-      "integrity": "sha512-yRx5ag3xEQ/yGvyo80FVukS7ZkeUP49Vbzg0MjfHLkuCIgg5lFtaEJfZR178KJmjWPqLU4d0P4k7SKgF9UkOaQ==",
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.26.0.tgz",
+      "integrity": "sha512-mLUktFAn+Pa2agl1J7VgtYNFWCX8/b4GMJSK1hCu4YCvtBfM6F8Os3EP4ry+DFFlXOf3wyvlgXhuUdFoy52D3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-base64": "^4.3.0",
-        "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.2",
-        "@smithy/util-stream": "^4.5.2",
-        "@smithy/util-utf8": "^4.2.0",
-        "@smithy/uuid": "^1.1.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/core/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -15581,15 +15930,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.2.tgz",
-      "integrity": "sha512-hOjFTK+4mfehDnfjNkPqHUKBKR2qmlix5gy7YzruNbTdeoBE3QkfNCPvuCK2r05VUJ02QQ9bz2G41CxhSexsMw==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.2.tgz",
+      "integrity": "sha512-18UMDMyrAbDcpmL1gLUA7ww0fRTcdCrSjSJOi2Sbld+tVjwD/pW+OAwjlScFLR7vvBnhZrIPQ7kVuTf1mnJLug==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.2",
-        "@smithy/property-provider": "^4.2.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/url-parser": "^4.2.2",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -15679,15 +16026,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.3.tgz",
-      "integrity": "sha512-cipIcM3xQ5NdIVwcRb37LaQwIxZNMEZb/ZOPmLFS9uGo9TGx2dGCyMBj9oT7ypH4TUD/kOTc/qHmwQzthrSk+g==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.5.2.tgz",
+      "integrity": "sha512-Ei/UK/QMhq0rKaMqGPlOAkE2yS9DZeYmZdk1RAKc3vp3zxgleZHZyBLlZv8yLsxljX4svCRuMTD6u3LLIcU4Bg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/querystring-builder": "^4.2.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-base64": "^4.3.0",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -15912,15 +16257,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.1.tgz",
-      "integrity": "sha512-9gKJoL45MNyOCGTG082nmx0A6KrbLVQ+5QSSKyzRi0AzL0R81u3wC1+nPvKXgTaBdAKM73fFPdCBHpmtipQwdQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.8.2.tgz",
+      "integrity": "sha512-wfl1uwrAqMH9/pi4kqBo5LBcFwrJLxuDLqL7p7qNcJIFcyZDUc6pzhYk4CYv+DP7fIUpQCZumwNnkhPKS52osQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.2",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/querystring-builder": "^4.2.2",
-        "@smithy/types": "^4.7.1",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -15947,20 +16290,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.7.1",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.2.tgz",
-      "integrity": "sha512-YgXvq89o+R/8zIoeuXYv8Ysrbwgjx+iVYu9QbseqZjMDAhIg/FRt7jis0KASYFtd/Cnsnz4/nYTJXkJDWe8wHg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16006,43 +16335,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.2.tgz",
-      "integrity": "sha512-BRnQGGyaRSSL0KtjjFF9YoSSg8qzSqHMub4H2iKkd+LZNzZ1b7H5amslZBzi+AnvuwPMyeiNv0oqay/VmIuoRA==",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.5.2.tgz",
+      "integrity": "sha512-7xHpmPY4rt0IOmeAA8EfjgEH8isT+587TCdy9H6a7d4OMi5CQ0oEHhWllunvPu4j4Cq0vTFwdxXN/kABWPjdyA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.2.0",
-        "@smithy/protocol-http": "^5.3.2",
-        "@smithy/types": "^4.7.1",
-        "@smithy/util-hex-encoding": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.2",
-        "@smithy/util-uri-escape": "^4.2.0",
-        "@smithy/util-utf8": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-hex-encoding": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
-      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/signature-v4/node_modules/@smithy/util-utf8": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
-      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/core": "^3.26.0",
+        "@smithy/types": "^4.15.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -16068,9 +16367,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.7.1.tgz",
-      "integrity": "sha512-WwP7vzoDyzvIFLzF5UhLQ6AsEx/PvSObzlNtJNW3lLy+BaSvTqCU628QKVvcJI/dydlAS1mSHQP7anKcxDcOxA==",
+      "version": "4.15.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.15.0.tgz",
+      "integrity": "sha512-Z5TAOxygoFvybJV3igo5SloFflSokHx2hu1eFA+DxDTcn+FtKxUSui+rbTRG1pAafMA888Z3MVvCWUuvCrTXjg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -16293,18 +16592,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/util-buffer-from": "^4.2.0",
-        "tslib": "^2.6.2"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@smithy/util-uri-escape": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
-      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
-      "license": "Apache-2.0",
-      "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -18624,6 +18911,15 @@
     "node_modules/aws-common-dependencies": {
       "resolved": "core/services/aws",
       "link": true
+    },
+    "node_modules/aws-jwt-verify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-4.0.1.tgz",
+      "integrity": "sha512-kzvi71eD3w/mCpYRUY7cz6DX4bfYihGdI2yV3FYQ2JuZZenqAqDPz0gWj0ew6vlAtdEVBNb7p+Dm2TAIxpVYMA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/aws-lambda": {
       "version": "1.0.7",


### PR DESCRIPTION
## Summary

Adds real-time, authenticated, participant-only **in-app chat** between a donor and a seeker, full-stack (backend business logic, AWS infrastructure, and the Expo mobile client). A chat channel opens automatically when a donor accepts a blood request (and re-opens on re-accept), locks when the request resolves (IGNORED, COMPLETED, CANCELLED, or EXPIRED), and purges messages after 90 days. Users get live delivery over WebSocket with an offline push-notification fallback, a channel inbox with an unread indicator, and paginated newest-first history. The whole feature is gated behind the `EXPO_PUBLIC_CHAT_ENABLED` build-time flag so it can be shipped dark and rolled out deliberately.

The work was delivered in seven dependency-ordered phases (domain model → service layer → infrastructure → handlers → OpenAPI/REST wiring → mobile data layer → mobile UI).

## Fixes / Resolves

- Resolves #571

## Type of change

- [x] Feature
- [x] Infra
- [ ] Bugfix
- [ ] Refactor
- [ ] Docs
- [ ] Other: __________

## What changed

### Domain model & DTOs (`commons/`)
- New `commons/dto/ChatDTO.ts`: `ChatChannelDTO`, `ChatMembershipDTO`, `ChatMessageDTO`, `ChatConnectionDTO`, the `ChatContextSnapshot`, `ChatChannelStatus`/`ChatRole` enums, and the shared `buildChannelId` / `parseChannelId` / `isChannelParticipant` helpers (one source of truth for the composite `channelId = "seekerId#requestPostId#donorId"`).
- Added `CHAT_MESSAGE` to the `NotificationType` enum.

### Business logic (`core/application/chatWorkflow/`)
- `ChatService` (AWS-free): `openChannel`, `sendMessage`, `listChannels`, `markRead`, `getHistory`, `lockChannel`, `lockChannelsForRequest`.
- Participant-only enforcement by parsing `channelId` (no DB read); send path enforces not-locked + an atomic DynamoDB **rate limit** (60 msg/min/channel).
- Three typed errors mapped to HTTP codes: not-a-participant (401), locked (400), rate-limited (429).
- `BloodDonationService` hook: locks channels on COMPLETED (per donor) and CANCELLED/EXPIRED (per request), via an optional injected `ChatService` (existing call sites unaffected).

### Storage (single DynamoDB table)
- Channel item (`PK=CHANNEL#<seekerId>#<requestPostId>`, `SK=DONOR#<donorId>`) with status + a request-context snapshot.
- Per-participant membership items (`PK=CHATUSER#<userId>`) so each user lists their own channels without a shared GSI.
- Time-ordered message items with a 90-day TTL; connection items keyed by `connectionId` with `GSI1` on `userId` for fanout.

### Infrastructure (`iac/terraform/aws/chat/`)
- Self-contained module: WebSocket API (`$connect`/`$disconnect`/`sendMessage` routes), a REQUEST Lambda authorizer on `$connect`, explicit deployment + stage, the six WS/pipe Lambdas and three REST Lambdas, and IAM.
- Two EventBridge **stream pipes**: INSERT(`ACCEPTED#`) → channel creator, REMOVE(`ACCEPTED#`) → channel locker.
- Enabled DynamoDB TTL on the shared `ttl` attribute.

### Lambda handlers (`core/services/aws/chat/`)
- `chatConnect` / `chatDisconnect`, `chatConnectAuthorizer` (verifies the Cognito access token with `aws-jwt-verify`), `chatChannelCreator` / `chatChannelLocker` (pipe handlers), `chatSendMessage` (resolve sender by connection, persist, fan out via `ApiGatewayManagementApi`, prune stale connections, enqueue offline push), and the `chatGetHistory` / `chatListChannels` / `chatMarkRead` REST handlers.

### REST API (`openapi/`)
- New `bloodconnect-chat` endpoints: `GET /chat/channels`, `POST /chat/history`, `PATCH /chat/read` (POST/PATCH with JSON bodies so the composite `channelId` and the opaque pagination cursor round-trip cleanly), wired to their Lambdas via `x-amazon-apigateway-integration` and VTL templates.

### Mobile (`clients/mobile/src/chat/`)
- Data layer: `ChatWebSocketClient` (exponential-backoff reconnect, offline send queue), `chatService` (REST), and the `useChatInbox` / `useChatRoom` hooks. Unread is derived client-side.
- UI: `ChatInbox` (channel list + unread badge), `ChatRoom` (sent/received bubbles, context header, read-only locked banner), and `ChatRoomHeader`.
- Entry points: a Chat button on the seeker's accepted-donor list and on the donor's "My Responses" card; `CHAT_MESSAGE` push deep-links to the room.
- Rollout gate: `isChatEnabled()` (`EXPO_PUBLIC_CHAT_ENABLED`) gates both the navigation routes and the entry-point buttons.

## Notable design decisions

- **Channel listing uses per-participant membership items, not a GSI** — the table's single overloaded GSI cannot index one channel under both participants.
- **Cancel/expire lock via an in-service hook**, not a stream pipe, because those transitions don't delete the acceptance record (no REMOVE event fires); only IGNORED does.
- **`getHistory` returns `{ channel: {status, context}, page }`**, not just messages, so the chat room header and locked banner render on a cold-start deep-link from the one call the room already makes — no separate post fetch. (The context was snapshotted onto the channel at creation specifically for this path.)
- **WebSocket auth** is a REQUEST Lambda authorizer with the access token on the querystring, because API Gateway v2 native JWT authorizers are HTTP-API-only and WS clients can't set `$connect` headers.

## Checklist

- [x] Tested locally (unit + render tests; full suite green — see below)
- [x] Added/updated tests or docs
- [x] Follows code style guidelines (ESLint clean on all changed files)

## Dependencies

- [ ] Depends on: #

## Testing & verification

- **Full suite:** `TZ=UTC npm test` → **52 suites / 384 tests pass** (the 2 `formattedDate` cases are local-timezone artifacts that pass under `TZ=UTC`/CI).
- **Backend:** `ChatService`, DDB adapters, pipe/REST/WS handlers, and the `BloodDonationService` lock hooks are unit-tested (`aws-sdk-client-mock`).
- **Mobile:** WS reconnect/backoff, offline-queue flush, unread derivation, markRead-on-open, `CHAT_MESSAGE` routing, and render tests for `ChatInbox` / `ChatRoom` (header on deep-link, open vs locked) plus the entry-point and rollout-flag gating.
- **Type-check:** zero errors reference any new/edited file (the few errors in touched files are pre-existing `Toast`/`FlatList` typings at shifted line numbers).
- **Infra:** `terraform validate` + `fmt -check` pass per-module for the `chat` and `dynamodb` modules; `make lint-api` is clean. Root `tf-validate` is deferred to CI (a pre-existing `template_file` provider limitation on darwin_arm64).

## Notes

- **No automated end-to-end test.** API Gateway v2 WebSocket APIs and EventBridge Pipes are LocalStack Pro-only, so the live WebSocket flow (connect → send → fanout → offline push) is verified manually on a deployed dev environment.
- **Shipping dark.** With `EXPO_PUBLIC_CHAT_ENABLED` unset, no chat routes or entry points are exposed and a build without `WEBSOCKET_URL` still succeeds.
- **Known risk (minor):** `listChannels` has no pagination cursor and membership items have no TTL, so a very prolific user's channel partition could eventually truncate at the 1 MB query page; mitigation is to add a cursor mirroring `getHistory` if it ever bites.
- **Out of scope:** read receipts, end-to-end encryption beyond TLS + at-rest, org/monitoring web dashboards, group chat, and media/attachments.

## Cost Breakdown (Claude Generated)

| Session  | Phase             | Local time             | Active work | Peak context | Cost (API-equiv) |
| -------- | ----------------- | ---------------------- | ----------- | ------------ | ---------------- |
| a5d82217 | /init + /plan     | 10:40 → finished later | 38 min      | 244K         | $23.82           |
| e65f1baa | /gg Phase 1       | 11:32 → 11:47          | 10 min      | 103K         | $9.66            |
| 9ff1ce90 | /gg Phase 2, 3, 4 | 11:47 → 16:51          | 88 min      | 380K         | $114.04          |
| 2cb410bd | /gg Phase 5       | 16:52 → 17:12          | 20 min      | 164K         | $19.62           |
| caf199cf | /gg Phase 6       | 17:14 → next day       | 25 min      | 156K         | $20.46           |
| e469dc3c | /gg Phase 7       | 17:39 → 00:18          | 74 min      | 276K         | $67.41           |

Feature total: ≈ $255 · Active work: ≈ 4.25 h · spread across a 14.2 h window (10:40 AM → 00:52 AM) because of the two ~5-hour limit resets you waited through.
